### PR TITLE
sssd: improve setup performance

### DIFF
--- a/sssd_test_framework/config.py
+++ b/sssd_test_framework/config.py
@@ -40,6 +40,7 @@ class SSSDMultihostDomain(MultihostDomain[SSSDMultihostConfig]):
         :rtype: Class name.
         """
         from .hosts.ad import ADHost
+        from .hosts.client import ClientHost
         from .hosts.ipa import IPAHost
         from .hosts.kdc import KDCHost
         from .hosts.ldap import LDAPHost
@@ -48,6 +49,7 @@ class SSSDMultihostDomain(MultihostDomain[SSSDMultihostConfig]):
 
         return {
             "ad": ADHost,
+            "client": ClientHost,
             "ldap": LDAPHost,
             "ipa": IPAHost,
             "samba": SambaHost,

--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -62,7 +62,7 @@ class BaseBackupHost(BaseHost, ABC):
             else:
                 self.ssh.exec(["rm", "-fr", self._backup_location])
 
-        super().teardown()
+        super().pytest_teardown()
 
     def setup(self) -> None:
         """

--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -1,0 +1,138 @@
+"""IPA multihost host."""
+
+from __future__ import annotations
+
+from pytest_mh.ssh import SSHLog
+
+from .base import BaseBackupHost
+
+__all__ = [
+    "ClientHost",
+]
+
+
+class ClientHost(BaseBackupHost):
+    """
+    SSSD client host object.
+
+    Provides features specific to SSSD client.
+
+    .. note::
+
+        Full backup and restore of SSSD state is supported.
+    """
+
+    def pytest_setup(self) -> None:
+        """
+        Called once before execution of any tests.
+
+        - override systemd unit to disable burst limiting, otherwise we will be
+          unable to restart the service frequently
+        - reload systemd to apply change to the unit file
+        """
+        super().pytest_setup()
+
+        self.logger.info("Creating SSSD systemd override")
+        self.ssh.run(
+            """
+            set -ex
+
+            backuppath="/tmp/mh.client.systemd.backup"
+            overridedir="/etc/systemd/system/sssd.service.d"
+            if [ -d "$overridedir" ] || [ -f "$overridedir" ]; then
+                cp --force --archive "$overridedir" "$backuppath"
+            fi
+
+            # Disable burst limiting to allow often sssd restarts for tests
+            mkdir -p "$overridedir"
+            cat <<EOF > "$overridedir/override.conf"
+            [Unit]
+            StartLimitIntervalSec=0
+            StartLimitBurst=0
+            EOF
+
+            # Reload systemd to pickup changes
+            systemctl daemon-reload
+            """,
+            log_level=SSHLog.Error,
+        )
+
+    def pytest_teardown(self) -> None:
+        """
+        Called once after all tests are finished.
+
+        - remove systemd changes
+        """
+        self.logger.info("Removing SSSD systemd override")
+        self.ssh.run(
+            """
+            set -ex
+
+            backuppath="/tmp/mh.client.systemd.backup"
+            overridedir="/etc/systemd/system/sssd.service.d"
+
+            rm -fr "$overridedir"
+            if [ -d "$overridedir" ] || [ -f "$overridedir" ]; then
+                mv --force "$backuppath" "$overridedir"
+            fi
+
+            # Reload systemd to pickup changes
+            systemctl daemon-reload
+            """,
+            log_level=SSHLog.Error,
+        )
+        super().pytest_teardown()
+
+    def backup(self) -> None:
+        """
+        Backup all SSSD data.
+        """
+        location = "/tmp/mh.client.sssd.backup"
+        self.logger.info(f"Creating backup of SSSD client at {location}")
+
+        self.ssh.run(
+            f"""
+            set -ex
+
+            function backup {{
+                if [ -d "$1" ] || [ -f "$1" ]; then
+                    cp --force --archive "$1" "$2"
+                fi
+            }}
+
+            mkdir -p "{location}"
+            backup /etc/sssd "{location}/config"
+            backup /var/log/sssd "{location}/logs"
+            backup /var/lib/sss "{location}/lib"
+            """,
+            log_level=SSHLog.Error,
+        )
+
+        self._backup_location = location
+
+    def restore(self) -> None:
+        """
+        Restore all SSSD data.
+        """
+        if not self._backup_location:
+            return
+
+        self.logger.info(f"Restoring SSSD data from {self._backup_location}")
+        self.ssh.run(
+            f"""
+            set -ex
+
+            function restore {{
+                rm --force --recursive "$2"
+                if [ -d "$1" ] || [ -f "$1" ]; then
+                    cp --force --archive "$1" "$2"
+                fi
+            }}
+
+            rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd
+            restore "{self._backup_location}/config" /etc/sssd
+            restore "{self._backup_location}/logs" /var/log/sssd
+            restore "{self._backup_location}/lib" /var/lib/sss
+            """,
+            log_level=SSHLog.Error,
+        )

--- a/sssd_test_framework/roles/client.py
+++ b/sssd_test_framework/roles/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..hosts.base import BaseHost
+from ..hosts.client import ClientHost
 from ..topology import SSSDTopologyMark
 from ..utils.automount import AutomountUtils
 from ..utils.local_users import LocalUsersUtils
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 
-class Client(BaseLinuxRole[BaseHost]):
+class Client(BaseLinuxRole[ClientHost]):
     """
     SSSD Client role.
 

--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -86,36 +86,15 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         Shortcuts to SSSD log paths.
         """
 
-    def setup(self) -> None:
+    def setup_when_used(self) -> None:
         """
         Setup SSSD on the host.
 
-        - override systemd unit to disable burst limiting, otherwise we will be
-          unable to restart the service frequently
-        - reload systemd to apply change to the unit file
-        - backup existing configuration and data
         - load configuration from the host (if requested in constructor) or set
           default configuration otherwise
 
         :meta private:
         """
-        # Disable burst limiting to allow often sssd restarts for tests
-        self.fs.mkdir("/etc/systemd/system/sssd.service.d")
-        self.fs.write(
-            "/etc/systemd/system/sssd.service.d/override.conf",
-            """
-            [Unit]
-            StartLimitIntervalSec=0
-            StartLimitBurst=0
-        """,
-        )
-        self.svc.reload_daemon()
-
-        # Backup existing SSSD data
-        self.fs.backup("/etc/sssd")
-        self.fs.backup("/var/lib/sss")
-        self.fs.backup("/var/log/sssd")
-
         # Load existing configuration if requested
         if self.__load_config:
             self.config_load()
@@ -127,7 +106,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
             [sssd]
             config_file_version = 2
             services = nss, pam
-        """
+            """
         )
 
     def async_start(


### PR DESCRIPTION
Avoid repeating operations that can be done only once:
- systemd override
- backup