### PR TITLE
samba: add nis-domain if gid is added to group

### DIFF
--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -564,6 +564,12 @@ class SambaGroup(SambaObject):
             "group-type": (self.cli.option.VALUE, category),
         }
 
+        # NIS Domain is required by samba-tool if gid number is set.
+        # It is stored in msSFU30NisDomain attribute of the group which is not
+        # used by SSSD so we can just provide hard coded value.
+        if gid is not None:
+            attrs["nis-domain"] = (self.cli.option.VALUE, "samba")
+
         self._add(attrs)
         return self
 


### PR DESCRIPTION
--nis-domain is required if group is created with POSIX gid, otherwise
we get:

```
Command #9 exited with return code 255:
  Command:
    samba-tool group add tgroup --gid-number 20001 --group-scope Global --group-type Security
  Error output:
    ERROR: Both --gid-number and --nis-domain have to be set for a RFC2307-enabled group. Operation cancelled.
```

The value is just stored in msSFU30NisDomain attribute of the group
which is not used by SSSD and does not have any meaning to use or samba.
Therefore we can just hard code the value instead of making it
configurable.