### PR TITLE
DBUS: Add support for D-Bus

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -10,6 +10,7 @@ How to guides
    pam
    testing-authentication
    testing-autofs
+   testing-dbus
    testing-gpo
    testing-identity
    testing-ldap-krb5

--- a/docs/guides/testing-dbus.rst
+++ b/docs/guides/testing-dbus.rst
@@ -1,0 +1,195 @@
+Testing D-Bus Services
+======================
+Infopipe
+--------
+Access to the Infopipe services is achieved through the
+:class:`sssd_test_framework.roles.client.Client` class. It provides the
+:meth:`sssd_test_framework.roles.client.Client.infopipe()` method that
+returns a pre-instantiated object of class
+:class:`sssd_test_framework.utils.sbus.DBUSDestination`, which gives you
+direct access to the `Infopipe` destination.
+
+With the destination, it is possible to get the different objects it provides.
+Each object has its own ``object path``. These objects are obtained by calling
+the destination's :meth:`sssd_test_framework.utils.sbus.DBUSDestination.getObject()`
+method. The object path must be passed as argument. A list containing all the
+available object paths can be retrieved with the method
+:meth:`sssd_test_framework.utils.sbus.DBUSDestination.getObjectPaths()`.
+
+.. note::
+    Passing an ``object path`` that doesn't exist will not generate an error nor
+    raise an exception. It will, instead, create a valid object with no attributes.
+    This is a strange behavior of ``Introspection``.
+
+Once you have one of these objects, you can access other D-BUS sub-objects
+provided by that destination by simply treating them as attributes of the
+parent object. **Methods** and **properties** are accessed in the same way.
+
+.. note::
+    Accessing an attribute that can't be mapped to a subobject, attribute or
+    method, will raise an :class:`AttributeError` exception.
+
+In the following example, there is an LDAP domain called `test`.
+
+.. code-block:: python
+    :caption: Infopipe Example
+
+    @pytest.mark.topology(KnownTopology.LDAP)
+    def test_infopipe__GetUserProperties(client: Client, provider: GenericProvider):
+        provider.user("user-1").add(uid=10001, gid=20001)
+
+        client.sssd.start()
+
+        users = client.ifp.getObject("/org/freedesktop/sssd/infopipe/Users");
+        user_path = users.FindByName("user-1")
+        assert "/org/freedesktop/sssd/infopipe/Users/test/10001" == user_path
+
+        user = client.ifp.getObject(user_path)
+        uid = user.Get("org.freedesktop.sssd.infopipe.Users.User", "uidNumber")
+        assert uid == 10001
+
+        gid = user.gidNumber
+        assert gid == 20001
+
+        props = user.GetAll("org.freedesktop.sssd.infopipe.Users.User")
+        assert props["uidNumber"] == 10001
+        assert props["gidNumber"] == 20001
+        assert props["name"] == "user-1"
+        assert props["homeDirectory"] == "/home/user-1"
+
+Internals
+---------
+Although :class:`sssd_test_framework.roles.client.Client` provides the
+:meth:`sssd_test_framework.roles.client.Client.infopipe()` method, the framework
+allows you to access any D-Bus destination. To achieve that you need to
+instantiate the :class:`sssd_test_framework.utils.sbus.DBUSDestination` class,
+providing the MultihostHost where the D-Bus services are running, the destination
+(the application) to contact and the bus to connect to.
+
+The bus can be the bus' path as a string, or one of the predefined buses:
+
+* :attr:`sssd_test_framework.utils.sbus.DBUSKnownBus.SYSTEM`
+* :attr:`sssd_test_framework.utils.sbus.DBUSKnownBus.SESSION`
+* :attr:`sssd_test_framework.utils.sbus.DBUSKnownBus.MONITOR`
+
+.. code-block:: python
+    :caption: Accessing the monitor
+
+    @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+    def test_example__monitor(client: Client):
+        client.sssd.start()
+
+        monitor = DBUSDestination(client.host, dest="sssd.monitor", bus=DBUSKnownBus.MONITOR)
+
+        sssd = monitor.getObject(objpath="/sssd")
+
+        res = sssd.debug_level
+        assert res == 0xFFF0
+
+        sssd.debug_level = 0x0070
+
+
+A Note On Type Conversion
+~~~~~~~~~~~~~~~~~~~~~~~~~
+All methods and properties accept and return Python types. Internally they are
+converted to some specific classes helping to treat them and map them to D-Bus
+types.
+
+Objects of these types represent values that are passed to/from the methods and
+properties. Their type is given by the class. For instance, DBUSTypeString is a
+D-Bus string.
+
+These classes are all subclasses of the abstract class
+:class:`sssd_test_framework.utils.dbus.types.DBUSType` and they provide the
+following methods:
+
+* :attr:`sssd_test_framework.utils.dbus.types.DBUSType.value`: A property to read
+  and set the (Python) value.
+* :meth:`sssd_test_framework.utils.dbus.types.DBUSType.mimic()`: a method to copy
+  itself without copying the value while maintaining the structure (subtypes).
+* :meth:`sssd_test_framework.utils.dbus.types.DBUSType.param()`: The string
+  representation of the value in a format suitable to be used as a parameter for
+  ``dbus-send``.
+* :meth:`sssd_test_framework.utils.dbus.types.DBUSType.parse()`: Parses the
+  string resulting from an execution of ``dbus-send`` and set the value to the
+  object.
+
+Basic types (integers, strings, booleans, etc.) are subclasses of the
+:class:`sssd_test_framework.utils.dbus.types.DBUSTypeBasic` abstract class.
+
+Container types -- that is, the subclasses of the abstract class
+:class:`sssd_test_framework.utils.dbus.types.DBUSTypeContainer` -- accept a
+parameter for their constructors, another
+:class:`sssd_test_framework.utils.dbus.types.DBUSType` object of the expected type.
+
+.. code-block:: python
+    :caption: Declaring an array of unit32
+
+    s = "array [ uint32 1 uint32 2 uint32 3 ]"
+    a = DBUSTypeArray(DBUSTypeUInt32())
+    a.parse(DBUSResult(s))
+    print(a.value)
+    [1, 2, 3]
+
+In some cases it may not be possible to know in advance the type of the elements
+of a container type. In that case, no object is passed to the constructor. The
+type will be guessed while parsing the result from ``dbus-send``.
+
+.. note::
+    ``dbus-send`` doesn't explain very well how container types are combined as
+    parameters, and so far we didn't use them. So we might have to adapt the
+    results of param() if they are ever used.
+
+.. note::
+    Using instrospection it is possible to get the methods and properties
+    signatures. Nevertheless, the signature for ``variant`` types does not include
+    the type of the contained type, as it does for the arrays and dictionaries.
+    Because of this, it is not possible to know in advance which type to expect
+    and will have to be guessed while parsing.
+
+Implemented Types
+~~~~~~~~~~~~~~~~~
+The following classes are already implemented.
+
+* :class:`sssd_test_framework.utils.dbus.types.DBUSType`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeBoolean`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeString`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeObjectPath`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeInteger`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeByte`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeInt16`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeInt32`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeInt64`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeUInt16`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeUInt32`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeUInt64`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeDouble`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeContainer`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeArray`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeDict`
+* :class:`sssd_test_framework.utils.dbus.types.DBUSTypeVariant`
+
+.. note::
+    Although the `D-Bus specification`_ considers ``dict entry`` a separate type,
+    we didn't implement it as such because there is no use case for it outside
+    of an array, in which case the array becomes a dictionary.
+
+.. _D-Bus specification: https://dbus.freedesktop.org/doc/dbus-specification.html#type-system
+
+Not Implemented Types
+~~~~~~~~~~~~~~~~~~~~~
+Some other classes were not implemented because they are not accepted by
+``dbus-send``:
+
+* signature
+* UNIX FD
+* struct
+
+Helper Classes
+~~~~~~~~~~~~~~
+Class :class:`sssd_test_framework.utils.dbus.types.DBUSSignatureReader` provides
+a single class method
+:meth:`sssd_test_framework.utils.dbus.types.DBUSSignatureReader.read()`
+used to read a method or property signature from a string and generate the
+corresponding :class:`sssd_test_framework.utils.dbus.types.DBUSType` objects
+required for the method or property.

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ It implements functionality such as:
 * NFS shares management
 * SSSD configuration and management
 * Automatic backup and restore of all hosts
+* D-Bus communication
 
 This framework can be used by other projects as well.
 

--- a/sssd_test_framework/roles/client.py
+++ b/sssd_test_framework/roles/client.py
@@ -9,6 +9,7 @@ from ..topology import SSSDTopologyMark
 from ..utils.automount import AutomountUtils
 from ..utils.ldb import LDBUtils
 from ..utils.local_users import LocalUsersUtils
+from ..utils.sbus import DBUSDestination, DBUSKnownBus
 from ..utils.sss_override import SSSOverrideUtils
 from ..utils.sssctl import SSSCTLUtils
 from ..utils.sssd import SSSDUtils
@@ -70,6 +71,13 @@ class Client(BaseLinuxRole[ClientHost]):
         self.sss_override: SSSOverrideUtils = SSSOverrideUtils(self.host, self.fs)
         """
         Managing local overrides users and groups.
+        """
+
+        self.ifp: DBUSDestination = DBUSDestination(
+            self.host, dest="org.freedesktop.sssd.infopipe", bus=DBUSKnownBus.SYSTEM
+        )
+        """
+        The D-bus destination for infopipe.
         """
 
     def setup(self) -> None:

--- a/sssd_test_framework/utils/dbus/types.py
+++ b/sssd_test_framework/utils/dbus/types.py
@@ -1,0 +1,804 @@
+"""D-Bus Type mapping to and from Python Types"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+__all__ = [
+    "DBUSResult",
+    "DBUSType",
+    "DBUSTypeBoolean",
+    "DBUSTypeString",
+    "DBUSTypeObjectPath",
+    "DBUSTypeInteger",
+    "DBUSTypeByte",
+    "DBUSTypeInt16",
+    "DBUSTypeInt32",
+    "DBUSTypeInt64",
+    "DBUSTypeUInt16",
+    "DBUSTypeUInt32",
+    "DBUSTypeUInt64",
+    "DBUSTypeDouble",
+    "DBUSTypeContainer",
+    "DBUSTypeArray",
+    "DBUSTypeDict",
+    "DBUSTypeVariant",
+    "DBUSSignatureReader",
+]
+
+
+# A NOTE ABOUT DBUS-SEND
+# **********************
+# It is important to know that dbus-send does not have a symmetric
+# behavior with relation to how the types are described in text
+# form when used as parameters or results.
+
+
+# TYPES PENDING IMPLEMENTATION
+# ****************************
+# The following D-Bus types are not implemented because they are not
+# currently recognized by dbus-send:
+# - Signature
+# - UNIX FD
+# - Struct
+
+
+class MutableString:
+    """A helper class implementing an extremely simple mutable string"""
+
+    def __init__(self, text: str):
+        self.text = text
+
+    def __str__(self):
+        return self.text
+
+
+class DBUSResult(MutableString):
+    """
+    The result from the D-Bus operation executed by dbus-send.
+    It is used to simplify parsing of the result as the string
+    must be modified and have no carriage return.
+    """
+
+    def __init__(self, text: str):
+        self.text = text.replace("\n", "")
+
+
+PythonType = TypeVar("PythonType")
+
+
+class DBUSType(ABC, Generic[PythonType]):
+    """
+    Abstract class to create classes that handle type conversion
+    between D-Bus and Python.
+    """
+
+    def __init__(self) -> None:
+        self._value: PythonType | None = None
+
+    @property
+    @abstractmethod
+    def _type_prefix(self) -> str:
+        """The D-Bus type prefix"""
+        pass
+
+    @property
+    @abstractmethod
+    def value(self) -> PythonType:
+        """The value as a Pyhton type"""
+        pass
+
+    @value.setter
+    @abstractmethod
+    def value(self, val: PythonType):
+        pass
+
+    def __str__(self) -> str:
+        """
+        Produce a string representation for the instantiated type's Python value.
+        """
+        return str(self.value)
+
+    @abstractmethod
+    def mimic(self) -> DBUSType[PythonType]:
+        """Duplicate this object. Structure is deepcopied, but values are not."""
+        pass
+
+    def param(self) -> str:
+        """
+        Produce a string representation for the instantiated type suitable for
+        using as a parameter for ``dbus-send``.
+        """
+        return f"{self._type_prefix}:{self}"
+
+    @abstractmethod
+    def parse(self, result: DBUSResult) -> None:
+        """
+        Parse a resulting string from ``dbus-send`` and instantiate
+        the corresponding ``DBUSType``.
+
+        It consumes the beginning of the provided result.
+        """
+        pass
+
+    @classmethod
+    def _guess_next_type(cls, result: DBUSResult) -> DBUSType:
+        """
+        Try to guess which is the next type.
+
+        This is mostly needed for variants whose signature doesn't include the subtype.
+        """
+        for subcls in cls.__subclasses__():
+            try:
+                # If one of our classes has subclasses, it means it is an intermediate
+                # abstract class and we need to make a recursive call. Otherwise,
+                # it is a concrete class and we can try to parse the value.
+                if not subcls.__subclasses__():
+                    obj = subcls()
+                    obj.parse(DBUSResult(result.text))
+                else:
+                    obj = subcls._guess_next_type(result)
+                return obj
+            except TypeError:
+                pass
+
+        raise TypeError("Couldn't guess the type")
+
+
+class DBUSTypeBasic(DBUSType[PythonType]):
+    """
+    Abstract class to group the basic types together.
+    """
+
+    def mimic(self) -> DBUSTypeBasic[PythonType]:
+        """Duplicate this object. Structure is deepcopied, but values are not."""
+        return self.__class__()
+
+
+class DBUSTypeInteger(DBUSTypeBasic[int]):
+    """
+    Abstract integer class to create classes that handle type conversion
+    between D-Bus and Python integers.
+    """
+
+    @property
+    @abstractmethod
+    def _match_exp(self) -> str:
+        """The regexp that must be matched during the type recognision"""
+        pass
+
+    @property
+    @abstractmethod
+    def _max_bit_length(self) -> int:
+        """The number of bit the type has"""
+        pass
+
+    @property
+    @abstractmethod
+    def _signed(self) -> bool:
+        """Whether the type is signed"""
+        pass
+
+    @property
+    def value(self) -> int:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return self._value
+
+    @value.setter
+    def value(self, val: int):
+        val = int(val)
+        if self._signed:
+            if val.bit_length() > self._max_bit_length - 1:
+                raise TypeError("Integer too large")
+        else:
+            if val < 0:
+                raise TypeError("Negative value")
+            if val.bit_length() > self._max_bit_length:
+                raise TypeError("Integer too large")
+
+        self._value = val
+
+    # A generic parsing method used by all the subclasses.
+    # It uses the class-specific `_match_exp` variable to adapt its behavior.
+    # It will be invoked from the concrete subclasses.
+    # It consumes the beginning of the provided result.
+    def parse(self, result: DBUSResult) -> None:
+        text = result.text
+        res = re.match(self._match_exp, text)
+        if res is None:
+            raise TypeError("Invalid integer")
+
+        result.text = text[res.span()[1] :].strip()
+        self.value = int(res.group(1))
+
+
+class DBUSTypeByte(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "byte"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *byte +([-+]?[0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 8
+
+    @property
+    def _signed(self) -> bool:
+        return False
+
+
+class DBUSTypeInt16(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "int16"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *int16 +([-+]?[0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 16
+
+    @property
+    def _signed(self) -> bool:
+        return True
+
+
+class DBUSTypeInt32(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "int32"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *int32 +([-+]?[0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 32
+
+    @property
+    def _signed(self) -> bool:
+        return True
+
+
+class DBUSTypeInt64(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "int64"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *int64 +([-+]?[0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 64
+
+    @property
+    def _signed(self) -> bool:
+        return True
+
+
+class DBUSTypeUInt16(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "int16"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *int16 +([-+]?[0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 16
+
+    @property
+    def _signed(self) -> bool:
+        return False
+
+
+class DBUSTypeUInt32(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "uint32"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *uint32 +([0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 32
+
+    @property
+    def _signed(self) -> bool:
+        return False
+
+
+class DBUSTypeUInt64(DBUSTypeInteger):
+    @property
+    def _type_prefix(self) -> str:
+        return "uint64"
+
+    @property
+    def _match_exp(self) -> str:
+        return r"^ *uint64 +([0-9]+)"
+
+    @property
+    def _max_bit_length(self) -> int:
+        return 64
+
+    @property
+    def _signed(self) -> bool:
+        return False
+
+
+class DBUSTypeDouble(DBUSTypeBasic[float]):
+    @property
+    def _type_prefix(self) -> str:
+        return "double"
+
+    @property
+    def value(self) -> float:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return self._value
+
+    @value.setter
+    def value(self, val: float):
+        self._value = float(val)
+
+    def parse(self, result: DBUSResult) -> None:
+        text = result.text
+        res = re.match(r"^ *double +([-+]?[0-9]+(\.[0-9]+)?)", text)
+        if res is None:
+            raise TypeError("Invalid double")
+
+        result.text = text[res.span()[1] :].strip()
+        self.value = float(res.group(1))
+
+
+class DBUSTypeBoolean(DBUSTypeBasic[bool]):
+    @property
+    def _type_prefix(self) -> str:
+        return "boolean"
+
+    @property
+    def value(self) -> bool:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return self._value
+
+    @value.setter
+    def value(self, val: bool):
+        self._value = bool(val)
+
+    # Parsing:   boolean false|true
+    def parse(self, result: DBUSResult) -> None:
+        text = result.text
+        res = re.match(r"^ *boolean +((true)|(false))", text, re.IGNORECASE)
+        if res is None:
+            raise TypeError("Not a boolean")
+
+        result.text = text[res.span()[1] :]
+        self.value = res.group(1).lower() == "true"
+
+    # Param:   boolean:false|true
+
+
+class DBUSTypeString(DBUSTypeBasic[str]):
+    @property
+    def _type_prefix(self) -> str:
+        return "string"
+
+    @property
+    def value(self) -> str:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return self._value
+
+    @value.setter
+    def value(self, val: str):
+        self._value = str(val)
+
+    def __str__(self) -> str:
+        return f"'{self.value}'"
+
+    # Parsing: string "My string"
+    def parse(self, result: DBUSResult) -> None:
+        text = result.text
+        res = re.match(r'^ *string +"([^"]*)"', text)
+        if res is None:
+            raise TypeError("Not a string")
+
+        result.text = text[res.span()[1] :].strip()
+        self.value = res.group(1)
+
+    # Param: string:"My string"
+
+
+class DBUSTypeObjectPath(DBUSTypeBasic[str]):
+    @property
+    def _type_prefix(self) -> str:
+        return "objpath"
+
+    @property
+    def value(self) -> str:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return self._value
+
+    @value.setter
+    def value(self, val: str):
+        self._value = str(val)
+
+    # Parsing: object path "/org/freedesktop/sssd/infopipe/Components/monitor"
+    def parse(self, result: DBUSResult) -> None:
+        text = result.text
+        res = re.match(r'^ *object path +"([^"]*)"', text)
+        if res is None:
+            raise TypeError("Not an object path")
+
+        result.text = text[res.span()[1] :].strip()
+        self.value = res.group(1)
+
+    # Param: objpath:/org/freedesktop/sssd/infopipe/Components/monitor
+
+
+class DBUSTypeContainer(DBUSType[PythonType]):
+    """
+    Abstract class to group the container types together.
+    """
+
+    pass
+
+
+class DBUSTypeVariant(DBUSTypeContainer[PythonType]):
+    """
+    Python representation for the D-Bus ``variant`` type.
+
+    This is a container for other types.
+    """
+
+    @property
+    def _type_prefix(self) -> str:
+        return "variant"
+
+    def __init__(self, model_element: DBUSType | None = None):
+        """
+        An object of the expected type can be passed as parameter.
+        This object will be used as a model.
+
+        If the object is not passed, we will try to guess it. This behavior is
+        required because the variant type doesn't include the subtype in the
+        signature.
+        """
+        self._element: DBUSType | None = None if model_element is None else model_element.mimic()
+        """The element stored by the variant"""
+
+    @property
+    def value(self) -> PythonType:
+        if self._element is None:
+            raise ValueError("No subtype set for Variant")
+        return self._element.value
+
+    @value.setter
+    def value(self, val: PythonType):
+        if self._element is None:
+            raise ValueError("No subtype set for Variant")
+        self._element.value = val
+
+    def __str__(self) -> str:
+        return str(self._element)
+
+    def mimic(self) -> DBUSTypeVariant:
+        return self.__class__(self._element)
+
+    # Parsing:  variant <type> <value>
+    def parse(self, result: DBUSResult) -> None:
+        res = re.match(r"^ *variant +", result.text)
+        if res is None:
+            raise TypeError("Not a variant")
+
+        old_text = result.text
+        result.text = result.text.removeprefix(res.group(0))
+
+        if self._element is None:
+            self._element = DBUSType._guess_next_type(result)
+
+        try:
+            self._element.parse(result)
+        except Exception as e:
+            result.text = old_text
+            raise e
+
+    # Param:  variant:<type>:<value>
+    def param(self) -> str:
+        if self._element is None:
+            raise ValueError("No value set")
+        return f"{self._type_prefix}:{self._element.param()}"
+
+
+class DBUSTypeDict(DBUSTypeContainer[dict]):
+    @property
+    def _type_prefix(self) -> str:
+        return "dict"
+
+    def __init__(self, model_key: DBUSTypeBasic | None = None, model_value: DBUSType | None = None):
+        """
+        Build a dictionary containing elements of a single type and keys of
+        another type.
+
+        An object of each type can be passed as parameter. This object will be
+        mimic'ed to create the elements when values are assigned.
+
+        If the objects are not passed, we will try to guess them. This behavior
+        is required because the variant type doesn't include the subtype in
+        the signature.
+        """
+        if (model_key is None or model_value is None) and model_key != model_value:
+            raise ValueError("Both arguments or none must be None")
+
+        self._model_key = model_key
+        self._model_value = model_value
+        self._str: str | None = None
+
+    @property
+    def value(self) -> dict:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return dict(self._value)
+
+    @value.setter
+    def value(self, val: dict):
+        if self._model_key is None or self._model_value is None:
+            raise ValueError("No subtype set")
+
+        self._value = dict(val)
+        self._dict = {}
+        for k in val.keys():
+            ko = self._model_key.mimic()
+            ko.value = k
+            vo = self._model_value.mimic()
+            vo.value = val[k]
+            self._dict[ko] = vo
+
+    def __str__(self) -> str:
+        if self._str is None:
+            val = ""
+            delim = ""
+            for k, v in self._dict.items():
+                val += f"{delim}{k},{v}"
+                delim = ","
+            self._str = val
+
+        return self._str
+
+    def mimic(self) -> DBUSTypeDict:
+        return self.__class__(self._model_key, self._model_value)
+
+    # We may need to handle dict entry as a separate type as that's how D-Bus
+    # considers it.
+    # For the moment, there is no gain in doing it, so we keep this.
+    def _parse_dict_entry(self, result: DBUSResult) -> tuple:
+        res = re.match(r"^ *dict entry *\(", result.text)
+        if res is None:
+            raise TypeError("Not a dictionary entry")
+
+        result.text = result.text.removeprefix(res.group(0))
+
+        if self._model_key is None:
+            k = DBUSType._guess_next_type(DBUSResult(result.text))
+            if not isinstance(k, DBUSTypeBasic):
+                raise ValueError(f"Basic type expected but got {k.__class__}")
+            self._model_key = k
+        key = self._model_key.mimic()
+        key.parse(result)
+
+        if self._model_value is None:
+            self._model_value = DBUSType._guess_next_type(DBUSResult(result.text))
+        value = self._model_value.mimic()
+        value.parse(result)
+
+        res = re.match(r"^ *\) *", result.text)
+        if res is None:
+            raise TypeError("Malformed dictionary entry: unfinished expression")
+
+        result.text = result.text.removeprefix(res.group(0)).strip()
+        return key, value
+
+    # Parsing: (without the newlines)
+    #     array [
+    #        dict entry(
+    #           <key type> <key>
+    #           <value type> <value>
+    #        )
+    #        ...
+    #     ]
+    def parse(self, result: DBUSResult) -> None:
+        match1 = re.match(r"^( *array +\[ *)dict entry *\(.+\) *\]", result.text)
+        if match1 is None:
+            raise TypeError("Not a dictionary")
+
+        odict = {}
+        pdict = {}
+        result2 = DBUSResult(result.text.removeprefix(match1.group(1)).strip())
+        match2 = re.match(r"^ *\] *", result2.text)
+        while len(result2.text) > 0 and match2 is None:
+            key, value = self._parse_dict_entry(result2)
+            odict[key] = value
+            pdict[key.value] = value.value
+            match2 = re.match(r"^ *\] *", result2.text)
+
+        if match2 is None:
+            raise TypeError("Malformed dictionary: unfinished expression")
+
+        result.text = result2.text.removeprefix(match2.group(0)).strip()
+        self._value = pdict
+        self._dict = odict
+
+    # Param: dict:<key type>:<value type>:<key>,<value>[,<key>,<value>]...
+    def param(self) -> str:
+        if self._model_key is None or self._model_value is None:
+            raise ValueError("No subtype set")
+
+        str = f"{self._type_prefix}:{self._model_key._type_prefix}:"
+        str += f"{self._model_value._type_prefix}:{self}"
+        return str
+
+
+class DBUSTypeArray(DBUSTypeContainer[list]):
+    @property
+    def _type_prefix(self) -> str:
+        return "array"
+
+    def __init__(self, model_element: DBUSType | None = None):
+        """
+        Build an array containing elements of a single type. An object of
+        this type can be passed as parameter. This object will be mimic'ed
+        to create the elements when values are assigned.
+
+        If the object is not passed, we will try to guess it. This behavior
+        is required because the variant type doesn't include the subtype in
+        the signature.
+        """
+        self._model_element = model_element
+        self._str: str | None = None
+
+    @property
+    def value(self) -> list:
+        if self._value is None:
+            raise ValueError("Value has not been set")
+        return list(self._value)
+
+    @value.setter
+    def value(self, val: list):
+        if self._model_element is None:
+            raise ValueError("No subtype set")
+
+        self._value = list(val)
+        self._array = []
+        for v in val:
+            vo = self._model_element.mimic()
+            vo.value = v
+            self._array.append(vo)
+
+    def __str__(self) -> str:
+        if self._str is None:
+            val = ""
+            delim = ""
+            for v in self._array:
+                val += delim + str(v)
+                delim = ","
+            self._str = val
+
+        return self._str
+
+    def mimic(self) -> DBUSTypeArray:
+        return self.__class__(self._model_element)
+
+    # Parsing:  array [ <type> <value> [ <type> <value> ]... ]
+    def parse(self, result: DBUSResult) -> None:
+        old = result.text
+        match = re.match(r"^ *array +\[", result.text)
+        if match is None:
+            raise TypeError("Not an array")
+
+        oarray = []
+        parray = []
+        result.text = result.text.removeprefix(match.group(0)).strip()
+        match = re.match(r"^ *\] *", result.text)
+        while len(result.text) > 0 and match is None:
+            if self._model_element is None:
+                self._model_element = DBUSType._guess_next_type(DBUSResult(result.text))
+
+            obj = self._model_element.mimic()
+            obj.parse(result)
+
+            oarray.append(obj)
+            parray.append(obj.value)
+            result.text = result.text.strip()
+            match = re.match(r"^\] *", result.text)
+
+        if match is None:
+            result.text = old
+            raise TypeError("Malformed array: unfinished expression")
+
+        result.text = result.text.removeprefix(match.group(0))
+        self._array = oarray
+        self._value = parray
+
+    # Param:  array:<type>:<value>[,<value>...]
+    def param(self) -> str:
+        if self._model_element is None:
+            raise ValueError("No subtype set")
+
+        return f"{self._type_prefix}:{self._model_element._type_prefix}:{self}"
+
+
+class DBUSSignatureReader:
+    """
+    D-Bus type builder from the method signature.
+    """
+
+    _type_mapping: dict[str, tuple] = {
+        "a{": (DBUSTypeDict, 2, "}"),  # Must be placed before "a"
+        "a": (DBUSTypeArray, 1, None),
+        "b": (DBUSTypeBoolean, 0, None),
+        "d": (DBUSTypeDouble, 0, None),
+        "i": (DBUSTypeInt32, 0, None),
+        "n": (DBUSTypeInt16, 0, None),
+        "o": (DBUSTypeObjectPath, 0, None),
+        "q": (DBUSTypeUInt16, 0, None),
+        "s": (DBUSTypeString, 0, None),
+        "t": (DBUSTypeUInt64, 0, None),
+        "u": (DBUSTypeUInt32, 0, None),
+        "v": (DBUSTypeVariant, 0, None),
+        "x": (DBUSTypeInt64, 0, None),
+        # Types not implemented by dbus-send.
+        # "g": (Signature, 0, None),
+        # "h": (UNIX FD, 0, None),
+        # "(": (Struct, 0, ")")
+    }
+    """
+    The mapping between dbus type codes and `DBUSType`s.
+
+    Taken from `the D-Bus specification <https://dbus.freedesktop.org/doc/dbus-specification.html#basic-types>`
+    """
+
+    @classmethod
+    def read(cls, signature: str | MutableString) -> DBUSType:
+        if isinstance(signature, str):
+            signature = MutableString(signature)
+
+        for prefix in cls._type_mapping.keys():
+            if signature.text.startswith(prefix):
+                dbustype, items, suffix = cls._type_mapping[prefix]
+                reminder = MutableString(signature.text.removeprefix(prefix))
+
+                objs = []
+                for i in range(items):
+                    obj = cls.read(reminder)
+                    objs.append(obj)
+
+                if suffix is not None:
+                    if not reminder.text.startswith(suffix):
+                        raise ValueError(
+                            f"Found the prefix '{prefix}' but no suffix " f"'{suffix}' in the signature '{signature}'"
+                        )
+
+                    reminder.text = reminder.text.removeprefix(suffix)
+
+                signature.text = reminder.text
+                tobjs = tuple(objs)
+                return dbustype(*tobjs)
+
+        raise ValueError(f"Unidentified signature '{signature}'")

--- a/sssd_test_framework/utils/sbus.py
+++ b/sssd_test_framework/utils/sbus.py
@@ -1,0 +1,450 @@
+"""Manage D-Bus operations"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as xml
+from abc import ABC
+from typing import Any, Final
+
+from pytest_mh import MultihostHost, MultihostUtility
+from pytest_mh.ssh import SSHProcessResult
+
+from .dbus.types import DBUSResult, DBUSSignatureReader, DBUSType, DBUSTypeString, DBUSTypeVariant
+
+__all__ = [
+    "DBUSDestination",
+    "DBUSKnownBus",
+]
+
+
+class DBUSKnownBus(str):
+    """
+    Weel-known D-Bus buses.
+    """
+
+    SYSTEM: Final = "--SYSTEM--"
+    """The system bus"""
+
+    SESSION: Final = "--SESSION--"
+    """The session bus"""
+
+    MONITOR: Final = "unix:path=/var/lib/sss/pipes/private/sbus-monitor"
+    """Monitor's private bus"""
+
+
+class ProxyObject(ABC):
+    """
+    Abstract class representing a D-Bus object (method or property).
+
+    Corresponding concrete classes are provided for their instantiation.
+    """
+
+    def __init__(
+        self,
+        host: MultihostHost,
+        dest: str,
+        objpath: str,
+        bus: str,
+        /,
+        interface: str | None = None,
+        child: xml.Element | None = None,
+    ):
+        """
+        Constructor to be called by the subclasses either explicitely or by inheritance.
+        """
+        match bus:
+            case DBUSKnownBus.SYSTEM:
+                _bus_param = "--system"
+            case DBUSKnownBus.SESSION:
+                _bus_param = "--session"
+            case _:
+                _bus_param = "--bus=" + bus
+
+        self.host = host
+        self.dest = dest
+        self.objpath = objpath
+        self.bus = bus
+        self.interface = objpath[1:].replace("/", ".") if interface is None else interface
+        self.child = child
+        self.cmd = f"dbus-send {_bus_param} --print-reply --dest={dest} {self.objpath}"
+
+    def _run(self, command: str, *args):
+        """
+        Run dbus-send over ssh on the remote host.
+        """
+        cmd = self.cmd + f" {command}"
+        for arg in args:
+            cmd += " " + arg.param()
+
+        result = self.host.ssh.run(cmd)
+        if result.stdout_lines[0].startswith("method return"):
+            lines = result.stdout_lines[1:]
+        else:
+            lines = result.stdout_lines
+
+        return SSHProcessResult(result.rc, lines, result.stderr_lines)
+
+
+class ProxyProperty(ProxyObject):
+    """
+    A D-Bus property accessible as an object
+    """
+
+    # interface and child are mandatory for this class
+    def __init__(
+        self,
+        host: MultihostHost,
+        dest: str,
+        objpath: str,
+        bus: str,
+        /,
+        interface: str,
+        child: xml.Element,
+        type: DBUSType,
+    ):
+        super().__init__(host, dest, objpath, bus, interface=interface, child=child)
+        # Properties always return a variant of the provided type.
+        self.type: DBUSTypeVariant = DBUSTypeVariant(type)
+        # access can be "read", "write" or "readwrite"
+        self.readable = "read" in child.attrib["access"]
+        self.writable = "write" in child.attrib["access"]
+        self.arg_interface = DBUSTypeString()
+        self.arg_interface.value = self.interface
+        self.arg_name = DBUSTypeString()
+        self.arg_name.value = self.child.attrib["name"]  # type: ignore[union-attr]
+
+    def get_value(self) -> Any:
+        """
+        Get the property's value
+        """
+        if not self.readable:
+            raise PermissionError("Execution failed: not a readable property")
+
+        res = self._run("org.freedesktop.DBus.Properties.Get", self.arg_interface, self.arg_name)
+        if res.rc != 0:
+            raise RuntimeError(res.stderr)
+
+        ret = self.type.mimic()
+        ret.parse(DBUSResult(res.stdout))
+        return ret.value
+
+    def set_value(self, value) -> None:
+        """
+        Set the property's value
+        """
+        if not self.writable:
+            raise RuntimeError("Execution failed: not a writable property")
+
+        val = self.type.mimic()
+        val.value = value
+
+        res = self._run("org.freedesktop.DBus.Properties.Set", self.arg_interface, self.arg_name, val)
+        if res.rc != 0:
+            raise RuntimeError(res.stderr)
+
+
+class ProxyMethod(ProxyObject):
+    """
+    A D-Bus method accessible as an object
+    """
+
+    def __init__(
+        self,
+        host: MultihostHost,
+        dest: str,
+        objpath: str,
+        bus: str,
+        /,
+        interface: str | None = None,
+        child: xml.Element | None = None,
+        input: list[DBUSType] | None = None,
+        output: list[DBUSType] | None = None,
+    ):
+        super().__init__(host, dest, objpath, bus, interface, child)
+        self.input = input
+        self.output = output
+
+    def __call__(self, *args) -> Any:
+        """
+        Execute the method
+        """
+        # In some internal cases we don't provide the child nor the interface at
+        # at instantiation because we don't use them, but on normal calls they are
+        # required.
+        if self.child is None:
+            raise RuntimeError("Execution failed: no child.")
+        if self.interface is None:
+            raise RuntimeError("Execution failed: no interface.")
+
+        objargs = []
+        if self.input is not None:
+            for i in range(len(self.input)):
+                obj = self.input[i].mimic()
+                try:
+                    obj.value = args[i]
+                except IndexError:
+                    raise RuntimeError(
+                        f"Execution failed: {len(self.input)} " f"arguments required but only {i} provided."
+                    )
+                objargs.append(obj)
+
+        method = f'{self.interface}.{self.child.attrib["name"]}'
+        res = self._run(method, *tuple(objargs))
+        if res.rc != 0:
+            raise RuntimeError(f'Execution of \'{self.child.attrib["name"]}{args}\' failed: ' + res.stderr)
+
+        if self.output is None:
+            ret = None
+        else:
+            values = []
+            result = DBUSResult(res.stdout)
+            for i in range(len(self.output)):
+                obj = self.output[i].mimic()
+                obj.parse(result)
+                values.append(obj.value)
+
+            ret = tuple(values) if len(values) > 1 else values[0]
+
+        return ret
+
+
+class DBUSObject:
+    """
+    A D-Bus object accesible as a Python object.
+
+    Objects of this class represent D-Bus nodes.
+    """
+
+    def __init__(self, host: MultihostHost, *, dest: str, objpath: str, bus: str):
+        self.host = host
+        self._properties: dict[Any, Any] = {}
+        self._objpath = objpath
+        self._dest = dest
+        self._bus = bus
+
+        introspection = ProxyMethod(host, dest, objpath, bus)
+        res = introspection._run("org.freedesktop.DBus.Introspectable.Introspect")
+        if res.rc != 0:
+            raise RuntimeError(f"Instrospection failed for {objpath}")
+
+        xmlstr = res.stdout.removeprefix('   string "').removesuffix('"')
+        self._xml = xml.fromstring(xmlstr)
+
+    def _find_child_node(self, root, name: str):
+        """
+        Find an XML child element of the given name.
+        """
+        for child in root:
+            if child.attrib["name"] == name:
+                return child
+            if child.tag == "interface":
+                res = self._find_child_node(child, name)
+                if res is not None:
+                    return res
+
+        return None
+
+    def _find_interface(self, elem: xml.Element) -> xml.Element | None:
+        """
+        Find the interface the provided XML element belongs to.
+        """
+        for child in self._xml:
+            if child.tag == "interface":
+                found = self._find_child_node(child, elem.attrib["name"])
+                if found == elem:
+                    return child
+
+        return None
+
+    def _get_method_args(self, method: xml.Element, dir: str) -> list[DBUSType]:
+        """
+        Get a list of DBUSType objects produced from the given method's signature.
+
+        The direction must be "in" or "out."
+        """
+        params = []
+        for arg in method:
+            if arg.tag == "arg" and arg.attrib["direction"] == dir:
+                params.append(DBUSSignatureReader.read(arg.attrib["type"]))
+        return params
+
+    def _get_property_type(self, prop: xml.Element) -> DBUSType:
+        return DBUSSignatureReader.read(prop.attrib["type"])
+
+    def _make_prop(self, child: xml.Element) -> ProxyProperty:
+        """
+        Add a D-Bus proxy property to the current node.
+        """
+        iface = self._find_interface(child)
+        if iface is None:
+            raise RuntimeError(f"No interface found for {child.attrib['name']}")
+
+        type = self._get_property_type(child)
+
+        prop = ProxyProperty(
+            self.host, self._dest, self._objpath, self._bus, interface=iface.attrib["name"], child=child, type=type
+        )
+        self._properties[child.attrib["name"]] = prop
+        return prop.get_value()
+
+    def _make_method(self, child) -> ProxyMethod:
+        """
+        Add a D-Bus proxy method to the current node.
+        """
+        iface = self._find_interface(child)
+        if iface is None:
+            raise RuntimeError(f"No interface found for {child.attrib['name']}")
+
+        input = self._get_method_args(child, "in")
+        output = self._get_method_args(child, "out")
+
+        method = ProxyMethod(
+            self.host,
+            self._dest,
+            self._objpath,
+            self._bus,
+            interface=iface.attrib["name"],
+            child=child,
+            input=input,
+            output=output,
+        )
+        self.__setattr__(child.attrib["name"], method)
+        return method
+
+    def _make_node(self, child) -> DBUSObject:
+        """
+        Add a D-Bus child node to the current node.
+        """
+        node = DBUSObject(
+            self.host, objpath=self._objpath + "/" + child.attrib["name"], dest=self._dest, bus=self._bus
+        )
+        self.__setattr__(child.attrib["name"], node)
+        return node
+
+    def _make_attr(self, child):
+        """
+        Make a D-Bus attribute and add it to the current node.
+        """
+        match child.tag:
+            case "property":
+                obj = self._make_prop(child)
+            case "method":
+                obj = self._make_method(child)
+            case "node":
+                obj = self._make_node(child)
+            case _:
+                raise AttributeError(
+                    f"'{self.__class__.__name__}' object has an attribute '{child.attrib['name']}'"
+                    f" of unkown type '{child.tag}'"
+                )
+
+        return obj
+
+    def __getattr__(self, attr) -> Any:
+        """
+        When acccessing an attribute that doesn't belong to the object,
+        create it if it should exist.
+        """
+
+        # This check avoids extra and recursive calls during object initialization
+        if "_properties" in self.__dict__ and attr in self._properties:
+            return self._properties[attr].get_value()
+
+        # This check avoids extra and recursive calls during object initialization
+        # if "_find_child" in self.__dict__ and "_xml" in self.__dict__:
+        if "_xml" in self.__dict__:
+            c = self._find_child_node(self._xml, attr)
+            if c is not None:
+                return self._make_attr(c)
+
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
+
+    def __setattr__(self, attr: str, value: Any) -> None:
+        """
+        If the caller sets a property, invoke the set_value() method
+        of the corresponding proxy property.
+        """
+        # This check avoids extra and recursive calls during object initialization
+        if "_properties" in self.__dict__ and attr in self._properties:
+            return self._properties[attr].set_value(value)
+
+        return super().__setattr__(attr, value)
+
+
+class DBUSDestination(MultihostUtility[MultihostHost]):
+    def __init__(self, host: MultihostHost, dest: str, bus: str):
+        """
+        Create a destination object associated to a bus and a name.
+
+        .. code-block:: python
+            :caption: Example
+
+            monitor = DBUSDestination(client.host, dest="sssd.monitor", bus=DBUSKnownBus.MONITOR)
+
+            paths = monitor.getObjectPaths()
+            assert len(paths) == 2
+            assert "/" in paths
+            assert "/sssd" in paths
+
+            sssd = monitor.getObject(objpath="/sssd")
+            sssd.debug_level = 0x0070
+            assert sssd.debug_level == 0x0070
+
+        .. _test code:
+           https://github.com/aplopez/sssd/blob/dbus/src/tests/system/tests/test_infopipe.py
+
+        A few more examples can be seen in the `test code`_.
+
+        :param host: The host where the D-Bus serices run.
+        :type host: MultihostHost
+        :param dest: Destination application to contact.
+        :type dest: str
+        :param bus: The bus to use for the communications. Defaults to ``DBUSBus.SYSTEM``.
+            For other cases, a string can be provided with the explicit bus path.
+        :type bus: str | DBUSBus, optional
+        """
+        super().__init__(host)
+        self._dest = dest
+        self._bus = bus
+        self._objPaths: list[str] | None = None
+
+    def _introspect(self, objPath: str) -> xml.Element:
+        introspection = ProxyMethod(self.host, self._dest, objPath, self._bus)
+        res = introspection._run("org.freedesktop.DBus.Introspectable.Introspect")
+        if res.rc != 0:
+            raise RuntimeError(f"Introspection failed for {objPath}")
+
+        xmlstr = res.stdout.removeprefix('   string "').removesuffix('"')
+        return xml.fromstring(xmlstr)
+
+    def _listNodes(self, path: str) -> list[str]:
+        lst: list[str] = []
+
+        root = self._introspect(path)
+        if root.tag == "node":
+            lst.append(path)
+            for child in root:
+                if child.tag == "node":
+                    childPath = (path if path != "/" else "") + "/" + child.attrib["name"]
+                    lst += self._listNodes(childPath)
+
+        return lst
+
+    def getObjectPaths(self) -> list[str]:
+        """
+        Returns the list of the paths available at this destination.
+        """
+        if self._objPaths is None:
+            self._objPaths = self._listNodes("/")
+
+        return self._objPaths
+
+    def getObject(self, objpath: str) -> DBUSObject:
+        """
+        Creates and returns an object representing the D-Bus object and *object path*
+        associated to the *destination*.
+
+        :param objpath: The path to the object at destination.
+        :type objpath: str
+        """
+        return DBUSObject(self.host, dest=self._dest, objpath=objpath, bus=self._bus)


### PR DESCRIPTION
Provides a set of objects able to handle D-Bus operations: method invocation, property access and node navigation.

All this is automatically done by using introspection to detect the structure.

The back-end uses dbus-send as it must be executed through ssh.

Some example tests can be seen [here](https://github.com/aplopez/sssd/blob/dbus/src/tests/system/tests/test_infopipe.py). Once this PR approved, a new PR will be opened to merge these tests.

Documentation is part of this PR.

Resolves: https://issues.redhat.com/browse/SSSD-6323
