### PR TITLE
authentication: increase authentication timeout

### DIFF
--- a/sssd_test_framework/utils/authentication.py
+++ b/sssd_test_framework/utils/authentication.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-DEFAULT_AUTHENTICATION_TIMEOUT: int = 10
+DEFAULT_AUTHENTICATION_TIMEOUT: int = 20
 """Default timeout for authentication failure."""
 
 


### PR DESCRIPTION
Some actions may be quite slow (like waiting for SSSD timeouts to
go offline), let's increase the timeout. If this does not help in
long run, we should make the timeout configurable and set required
value in specific test cases.