### PR TITLE
hosts: add passkey feature detection in client and IPA

### DIFF
--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -42,6 +42,7 @@ class ClientHost(BaseBackupHost):
             set -ex
 
             [ -f "/usr/lib64/sssd/libsss_files.so" ] && echo "files-provider" || :
+            [ -f "/usr/libexec/sssd/passkey_child" ] && echo "passkey" || :
             """,
             log_level=SSHLog.Error,
         )
@@ -49,6 +50,7 @@ class ClientHost(BaseBackupHost):
         # Set default values
         self._features = {
             "files-provider": False,
+            "passkey": False,
         }
 
         self._features.update({k: True for k in result.stdout_lines})


### PR DESCRIPTION
## Description

This allows to skip passkey tests when the functionality isn't provided.

Requires: https://github.com/next-actions/pytest-mh/pull/15 and https://github.com/SSSD/sssd-test-framework/pull/42 to work.

## How to test

I have created a new branch, [ikerexxe/testmarker2](https://github.com/ikerexxe/sssd-test-framework/tree/testmarker2), that contains all the changes necessary from this project to test.

In the sssd project, where your test lies, edit the `requirements.txt` file to point to the revision that we'd like to test:
```
pytest
git+https://github.com/next-actions/pytest-importance
git+https://github.com/pbrezina/pytest-mh/@require
git+https://github.com/next-actions/pytest-ticket
git+https://github.com/next-actions/pytest-tier
git+https://github.com/next-actions/pytest-output
git+https://github.com/ikerexxe/sssd-test-framework/@testmarker2
```

Create a new test case that depends on the passkey functionality:
```
@pytest.mark.topology(KnownTopology.IPA)
@pytest.mark.builtwith(client="passkey", ipa="passkey")
def test_files_provider__example(client: Client, ipa: IPA):
    pass
```

Run the test and check that it works as expected.