### PR TITLE
markers: make builtwith generic

### DIFF
--- a/docs/guides/check-sssd-functionality.rst
+++ b/docs/guides/check-sssd-functionality.rst
@@ -36,3 +36,41 @@ Supported features
 ==================
 
 * ``files-provider`` - SSSD is built with files provider support
+
+Checking supported functionality in other roles
+###############################################
+
+Even though the main purpose and default setting of the
+``@pytest.mark.builtwith`` marker is to check built functionality of SSSD on the
+client machine, it is also possible to use this marker in a more generic way to
+check functionality on other hosts as well by adding keyword arguments to the
+marker. Each key is one of the test role fixture.
+
+.. code-block:: python
+
+    @pytest.mark.topology(KnownTopology.IPA)
+    @pytest.mark.builtwith(ipa="passkey")
+    def test_passkey_ipa__example(client: Client, ipa: IPA):
+        pass
+
+It is also possible to check for multiple features at once. In this case,
+features must be supported by all hosts, otherwise the test is skipped.
+
+.. code-block:: python
+
+    @pytest.mark.topology(KnownTopology.IPA)
+    @pytest.mark.builtwith(client="passkey", ipa="passkey")
+    def test_passkey_client_and_ipa__example(client: Client, ipa: IPA):
+        pass
+
+.. note::
+
+    It is also possible to specify multiple features at once as a list for more
+    complex requirements.
+
+    .. code-block:: python
+
+        @pytest.mark.topology(KnownTopology.IPA)
+        @pytest.mark.builtwith(client=["client-feature-1", "client-feature-2"], ipa=["ipa-feature-1", "ipa-feature-2"])
+        def test_example(client: Client, ipa: IPA):
+            pass

--- a/sssd_test_framework/markers.py
+++ b/sssd_test_framework/markers.py
@@ -6,7 +6,8 @@ from functools import partial
 
 import pytest
 
-from .roles.client import Client
+from .misc import to_list_of_strings
+from .roles.base import BaseRole
 
 
 def pytest_configure(config: pytest.Config):
@@ -21,11 +22,33 @@ def pytest_configure(config: pytest.Config):
     )
 
 
-def builtwith(item: pytest.Function, feature: str, client: Client) -> bool:
-    if feature not in client.features:
-        raise ValueError(f"{item.nodeid}::{item.originalname}: unknown feature '{feature}' for @pytest.mark.builtwith")
+def builtwith(item: pytest.Function, requirements: dict[str, str], **kwargs: BaseRole):
+    def value_error(msg: str) -> ValueError:
+        return ValueError(f"{item.nodeid}::{item.originalname}: @pytest.mark.builtwith: {msg}")
 
-    return client.features[feature]
+    errors: list[str] = []
+    for role, features in requirements.items():
+        if role not in kwargs:
+            raise value_error(f"unknown fixture '{role}'")
+
+        if not isinstance(kwargs[role], BaseRole):
+            raise value_error(f"fixture '{role}' is not instance of BaseRole")
+
+        obj = kwargs[role]
+        for feature in to_list_of_strings(features):
+            if feature not in obj.features:
+                raise value_error(f"unknown feature '{feature}' in '{role}'")
+
+            if not obj.features[feature]:
+                errors.append(f'{role} does not support "{feature}"')
+
+    if len(errors) == 1:
+        return (False, errors[0])
+    elif len(errors) > 1:
+        return (False, str(errors))
+
+    # All requirements were passed
+    return True
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -34,10 +57,17 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         raise TypeError(f"Unexpected item type: {type(item)}")
 
     for mark in item.iter_markers("builtwith"):
-        if len(mark.args) != 1:
+        requirements: dict[str, str] = {}
+
+        if len(mark.args) == 1 and not mark.kwargs:
+            # @pytest.mark.builtwith("files-provider")
+            #  -> check if "files-provider" is supported by client
+            requirements["client"] = mark.args[0]
+        elif not mark.args and mark.kwargs:
+            # @pytest.mark.builtwith(client="passkey", ipa="passkey") ->
+            # -> check if "passkey" is supported by both client and ipa
+            requirements = dict(mark.kwargs)
+        else:
             raise ValueError(f"{item.nodeid}::{item.originalname}: invalid arguments for @pytest.mark.builtwith")
 
-        feature = mark.args[0]
-        item.add_marker(
-            pytest.mark.require(partial(builtwith, item=item, feature=feature), f"SSSD was not built with {feature}")
-        )
+        item.add_marker(pytest.mark.require(partial(builtwith, item=item, requirements=requirements)))


### PR DESCRIPTION
The marker can now tests features on any role and on multiple roles
at once.

This will be usefull for testing passkey feature, e.g.

@pytest.mark.builtwith(client="passkey", ipa="passkey")

---

Requires: https://github.com/next-actions/pytest-mh/pull/15