### PR TITLE
Remove references to obsolete 'config_file_version' sssd.conf option

### DIFF
--- a/docs/guides/using-roles.rst
+++ b/docs/guides/using-roles.rst
@@ -281,7 +281,6 @@ accessed by ``client.sssd.domain``.
         # Outputs:
         #
         # [sssd]
-        # config_file_version = 2
         # services = nss, pam
         # domains = test
         #
@@ -312,7 +311,6 @@ import the domain manually.
         # Outputs:
         #
         # [sssd]
-        # config_file_version = 2
         # services = nss, pam
         # domains = test
         #

--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -104,7 +104,6 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         self.config.read_string(
             """
             [sssd]
-            config_file_version = 2
             services = nss, pam
             """
         )


### PR DESCRIPTION
'config_file_version' option is obsolete / optional for a long time already, its usage doesn't make any sense.
Moreover, I plan to remove it from SSSD code base in https://github.com/SSSD/sssd/pull/6924