### PR TITLE
MISC: attrs_parse() fixed error when multi-line value appeared

### DIFF
--- a/sssd_test_framework/misc/__init__.py
+++ b/sssd_test_framework/misc/__init__.py
@@ -17,16 +17,25 @@ def attrs_parse(lines: list[str], attrs: list[str] | None = None) -> dict[str, l
     :rtype: dict[str, list[str]]
     """
     out: dict[str, list[str]] = {}
-    for line in lines:
-        line = line.strip()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         if not line:
+            i += 1
             continue
 
-        (key, value) = map(lambda x: x.strip(), line.split(":", 1))
+        (key, value) = map(lambda x: x.lstrip(), line.split(":", 1))
+        while i < len(lines) - 1:
+            if lines[i + 1].startswith(" "):
+                value += lines[i + 1][1:]
+                i += 1
+            else:
+                break
+
         if attrs is None or key in attrs:
             out.setdefault(key, [])
             out[key].append(value)
-
+        i += 1
     return out
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,9 +20,8 @@ def test_attrs_parse__nofilter():
     param1: value1
     param2: value2
     param3: value3
-    """.split(
-        "\n"
-    )
+    """
+    lines = textwrap.dedent(lines).strip().split("\n")
 
     expected = {
         "param1": ["value1"],
@@ -39,16 +38,40 @@ def test_attrs_parse__filter():
     param2: value2
     param3: value3
     param4: value4
-    """.split(
-        "\n"
-    )
-
+    """
+    lines = textwrap.dedent(lines).strip().split("\n")
     expected = {
         "param2": ["value2"],
         "param3": ["value3"],
     }
 
     assert attrs_parse(lines, ["param2", "param3"]) == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (
+            ["cn: sudorules", "distinguishedName: objectSID=123,cn=id_m", " appings,cn=test,cn=sysdb"],
+            {"cn": ["sudorules"], "distinguishedName": ["objectSID=123,cn=id_mappings,cn=test,cn=sysdb"]},
+        ),
+        (
+            [
+                "description: My teacher is a good ",
+                " one but I do not like him",
+                "  very much: he wears a dirty c",
+                " oat.",
+            ],
+            {"description": ["My teacher is a good one but I do not like him very much: he wears a dirty coat."]},
+        ),
+        (
+            ["cn: sudorules", "numbers: one,", "  two,", "  three"],
+            {"cn": ["sudorules"], "numbers": ["one, two, three"]},
+        ),
+    ],
+)
+def test_attrs_parse__long_line(input, expected):
+    assert attrs_parse(input) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When LDAP attributes values are too long, they split into multiple lines. It can look like the example provided, where ``originalDN`` is the problematic attribute:
```
# record 11
dn: name=ae3c2c8c-4b8f-11ee-ac71-c6e1a1a33042,cn=hbac_rules,cn=custom,cn=test,cn=sysdb
originalDN: ipaUniqueID=ae3c2c8c-4b8f-11ee-ac71-c6e1a1a33042,cn=hbac,dc=ipa,dc
 =test
serviceCategory: all
```

And this caused an error in ``attrs_parse()`` function. I added two tests to check this error, so look there for better understanding of the problem.
This is not a very nice solution, but I couldn't think of a better one. Feel free to suggest changes.