### PR TITLE
Error when trying to run crash course tests

### DIFF
--- a/docs/course/course.rst
+++ b/docs/course/course.rst
@@ -20,8 +20,9 @@ You should be ready to execute the tests, if you setup the environment
 correctly. Go to the system tests directory (``src/tests/system``) of SSSD
 repository and run the tests from this course with:
 
-.. code-blocK:: text
-
+.. code-block:: text
+    
+    $ cp sssd-test-framework/docs/course/test_course.py sssd/src/tests/system/test_course.py
     $ pytest --mh-config=./mhc.yaml --mh-log-path=./log -v ./docs/course/test_course.py
 
 Take the Course


### PR DESCRIPTION
Hi, I encountered a problem when trying to run 
`$ pytest --mh-config=./mhc.yaml --mh-log-path=./log -v ./docs/course/test_course.py` from https://tests.sssd.io/en/latest/course/course.html. 
The file path for the test is wrong. At first, I tried changing it to `~/sssd-test-framework/docs/course/test_course.py`, but I kept hitting this error:
```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --mh-config=mhc.yaml --mh-log-path=./log
  inifile: None
```
After playing around, I discovered it worked if I copied the test-course.py file into the local dir (`~/sssd/src/tests/system`). It seems like pytest doesn't load the mh module if the test file is in a different directory.

My proposed change is to include a step in the docs to copy the test file over, but there might be a better solution.