### PR TITLE
attrs_parse: strip whitespace from end of key

### DIFF
--- a/sssd_test_framework/misc/__init__.py
+++ b/sssd_test_framework/misc/__init__.py
@@ -25,6 +25,7 @@ def attrs_parse(lines: list[str], attrs: list[str] | None = None) -> dict[str, l
             continue
 
         (key, value) = map(lambda x: x.lstrip(), line.split(":", 1))
+        key = key.strip()
         while i < len(lines) - 1:
             if lines[i + 1].startswith(" "):
                 value += lines[i + 1][1:]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -75,6 +75,33 @@ def test_attrs_parse__long_line(input, expected):
 
 
 @pytest.mark.parametrize(
+    "input,expected",
+    [
+        (
+            [
+                "DistinguishedName : CN=username,CN=Users,DC=ad,DC=test",
+                "Enabled           : True",
+                "GivenName         : dummyfirstname",
+                "Name              : username",
+                "ObjectClass       : user",
+                "SamAccountName    : username",
+            ],
+            {
+                "DistinguishedName": ["CN=username,CN=Users,DC=ad,DC=test"],
+                "Enabled": ["True"],
+                "GivenName": ["dummyfirstname"],
+                "Name": ["username"],
+                "ObjectClass": ["user"],
+                "SamAccountName": ["username"],
+            },
+        ),
+    ],
+)
+def test_attrs_parse__strip_extra_white_space(input, expected):
+    assert attrs_parse(input) == expected
+
+
+@pytest.mark.parametrize(
     "value,include,expected",
     [
         ("value1", "value1", ["value1"]),


### PR DESCRIPTION
AD user get data was being returned with left over white space at the end of the keys.  Changing lstrip to strip in attrs_parse misc function to remove the whitespace at the end of the keys as well as the beginning.