### PR TITLE
hosts: adding domain and realm variables

### DIFF
--- a/sssd_test_framework/hosts/ad.py
+++ b/sssd_test_framework/hosts/ad.py
@@ -35,16 +35,19 @@ class ADHost(BaseDomainHost):
 
         self._features: dict[str, bool] | None = None
 
-        self.ad_domain: str = self.client["ad_domain"]
-        """
-        Active Directory domain name.
-        """
-
         # Additional client configuration
         self.client.setdefault("id_provider", "ad")
         self.client.setdefault("access_provider", "ad")
         self.client.setdefault("ad_server", self.hostname)
         self.client.setdefault("dyndns_update", False)
+
+        # Use different default for domain
+        if "domain" not in self.config and "ad_domain" in self.client:
+            self.domain = self.client["ad_domain"]
+
+        # Use different default for realm
+        if "realm" not in self.config:
+            self.realm = self.domain.upper()
 
         # Lazy properties
         self.__naming_context: str | None = None

--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -134,6 +134,12 @@ class BaseDomainHost(BaseBackupHost):
         super().__init__(*args, **kwargs)
         self.client: dict[str, Any] = self.config.get("client", {})
 
+        self.domain: str = self.config.get("domain", "test")
+        """Identity domain name."""
+
+        self.realm: str = self.config.get("realm", self.domain.upper())
+        """Kerberos realm."""
+
 
 class BaseLDAPDomainHost(BaseDomainHost):
     """

--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -55,6 +55,14 @@ class IPAHost(BaseDomainHost):
         self.client.setdefault("ipa_server", self.hostname)
         self.client.setdefault("dyndns_update", False)
 
+        # Use different default for domain
+        if "domain" not in self.config and "ipa_domain" in self.client:
+            self.domain = self.client["ipa_domain"]
+
+        # Use different default for realm
+        if "realm" not in self.config:
+            self.realm = self.domain.upper()
+
     @property
     def features(self) -> dict[str, bool]:
         """

--- a/sssd_test_framework/hosts/kdc.py
+++ b/sssd_test_framework/hosts/kdc.py
@@ -40,9 +40,6 @@ class KDCHost(BaseDomainHost):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.realm: str = self.config.get("realm", "TEST")
-        self.krbdomain: str = self.config.get("domain", "test")
-
         self.client["auth_provider"] = "krb5"
 
     def backup(self) -> None:

--- a/sssd_test_framework/hosts/samba.py
+++ b/sssd_test_framework/hosts/samba.py
@@ -25,16 +25,19 @@ class SambaHost(BaseLDAPDomainHost):
 
         self._features: dict[str, bool] | None = None
 
-        self.ad_domain: str = self.client["ad_domain"]
-        """
-        Active Directory domain name.
-        """
-
         # Additional client configuration
         self.client.setdefault("id_provider", "ad")
         self.client.setdefault("access_provider", "ad")
         self.client.setdefault("ad_server", self.hostname)
         self.client.setdefault("dyndns_update", False)
+
+        # Use different default for domain
+        if "domain" not in self.config and "ad_domain" in self.client:
+            self.domain = self.client["ad_domain"]
+
+        # Use different default for realm
+        if "realm" not in self.config:
+            self.realm = self.domain.upper()
 
     @property
     def features(self) -> dict[str, bool]:

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -55,7 +55,7 @@ class AD(BaseWindowsRole[ADHost]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.domain: str = self.host.ad_domain
+        self.domain: str = self.host.domain
         """
         Active Directory domain name.
         """
@@ -623,7 +623,7 @@ class ADUser(ADObject):
             "OtherAttributes": (self.cli.option.PLAIN, self._attrs_to_hash(unix_attrs)),
             "Enabled": (self.cli.option.PLAIN, "$True"),
             "Path": (self.cli.option.VALUE, self.path),
-            "EmailAddress": (self.cli.option.PLAIN, f'{self.name}@{self.host.client["ad_domain"]}'),
+            "EmailAddress": (self.cli.option.PLAIN, f"{self.name}@{self.host.domain}"),
             "GivenName": (self.cli.option.PLAIN, "dummyfirstname"),
             "Surname": (self.cli.option.PLAIN, "dummylastname"),
         }

--- a/sssd_test_framework/roles/kdc.py
+++ b/sssd_test_framework/roles/kdc.py
@@ -142,8 +142,8 @@ class KDC(BaseLinuxRole[KDCHost]):
             }}
 
             [domain_realm]
-            .{self.host.krbdomain} = {self.host.realm}
-            {self.host.krbdomain} = {self.host.realm}
+            .{self.host.domain} = {self.host.realm}
+            {self.host.domain} = {self.host.realm}
         """
         ).lstrip()
 

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -51,7 +51,7 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.domain: str = self.host.ad_domain
+        self.domain: str = self.host.domain
         """
         Active Directory domain name.
         """


### PR DESCRIPTION
 - adding a generic domain and realm variable that can be used in tests, as provider.host.domain/realm
 - updated existing functions to find the domain to use the new variable instead
