### PR TITLE
ci: run also against latest pytest-mh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,25 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.x"]
+        upstream: ["upstream", "pypi"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+    - name: Detect skipped environments
+      id: skipenv
+      env:
+        UPSTREAM: ${{ matrix.upstream }}
+      run: |
+        set -ex
+        case $UPSTREAM in
+          upstream)
+            echo 'skipenv=.*(?<!upstream)$' >> $GITHUB_OUTPUT
+            ;;
+          *)
+            echo 'skipenv=.*-upstream$' >> $GITHUB_OUTPUT
+            ;;
+        esac
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
@@ -28,5 +43,9 @@ jobs:
 
         python -m pip install --upgrade pip
         pip install tox tox-gh
-    - name: Run tox
-      run: tox --colored=yes
+    - name: Prepare tox environment and install packages
+      run: |
+        tox --skip-env '${{ steps.skipenv.outputs.skipenv }}' --colored=yes --notest
+    - name: Run tests
+      run: |
+        tox --skip-env '${{ steps.skipenv.outputs.skipenv }}' --colored=yes --skip-pkg-install

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
-envlist = py3,py310,lint,docs
+envlist = {py3,py310,lint,docs}{,-upstream}
 
 [testenv]
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-tests.txt
+    upstream: git+https://github.com/next-actions/pytest-mh
 commands =
     pytest -vvv tests
 
-[testenv:lint]
+[testenv:lint{,-upstream}]
 deps =
+    {[testenv]deps}
     black
     flake8
     isort
@@ -22,15 +24,16 @@ commands =
     mypy --install-types --non-interactive sssd_test_framework tests
     black --check sssd_test_framework tests
 
-[testenv:docs]
+[testenv:docs{,-upstream}]
 changedir = docs
 allowlist_externals = make
 deps =
+    {[testenv]deps}
     -r{toxinidir}/docs/requirements.txt
 commands =
     make html SPHINXOPTS="-W --keep-going"
 
 [gh]
 python =
-    3.x = py3, lint, docs
-    3.10 = py310, lint, docs
+    3.x = {py3,lint,docs}{,-upstream}
+    3.10 = {py310,lint,docs}{,-upstream}


### PR DESCRIPTION
This will allow to check the code against both pypi and upstream version
of pytest-mh.