### PR TITLE
roles: add domain and realm to providers

### DIFF
--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -60,6 +60,11 @@ class AD(BaseWindowsRole[ADHost]):
         Active Directory domain name.
         """
 
+        self.realm: str = self.host.realm
+        """
+        Kerberos realm.
+        """
+
         self.auto_ou: dict[str, bool] = {}
         """Organizational units that were automatically created."""
 

--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -48,6 +48,22 @@ class GenericProvider(ABC, MultihostRole[BaseHost]):
 
     @property
     @abstractmethod
+    def domain(self) -> str:
+        """
+        Domain name.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def realm(self) -> str:
+        """
+        Kerberos realm.
+        """
+        pass
+
+    @property
+    @abstractmethod
     def features(self) -> dict[str, Any]:
         pass
 

--- a/sssd_test_framework/roles/ipa.py
+++ b/sssd_test_framework/roles/ipa.py
@@ -54,6 +54,16 @@ class IPA(BaseLinuxRole[IPAHost]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+        self.domain: str = self.host.domain
+        """
+        IPA domain name.
+        """
+
+        self.realm: str = self.host.realm
+        """
+        Kerberos realm.
+        """
+
         self.sssd: SSSDUtils = SSSDUtils(self.host, self.fs, self.svc, self.authselect, load_config=True)
         """
         Managing and configuring SSSD.

--- a/sssd_test_framework/roles/ldap.py
+++ b/sssd_test_framework/roles/ldap.py
@@ -64,6 +64,16 @@ class LDAP(BaseLinuxLDAPRole[LDAPHost]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+        self.domain: str = self.host.domain
+        """
+        LDAP domain name.
+        """
+
+        self.realm: str = self.host.realm
+        """
+        Kerberos realm.
+        """
+
         self.auto_uid: int = 23000
         """The next automatically assigned user id."""
 

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -53,7 +53,12 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
 
         self.domain: str = self.host.domain
         """
-        Active Directory domain name.
+        Samba domain name.
+        """
+
+        self.realm: str = self.host.realm
+        """
+        Kerberos realm.
         """
 
         self.automount: SambaAutomount = SambaAutomount(self)


### PR DESCRIPTION
This is a follow up of https://github.com/SSSD/sssd-test-framework/pull/74

@danlavu  It adds domain and realm to role objects as well as a shortcut.
