### PR TITLE
roles: adding gpo functions to AD role

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -10,6 +10,7 @@ How to guides
    pam
    testing-authentication
    testing-autofs
+   testing-gpo
    testing-identity
    testing-ldap-krb5
    testing-netgroups

--- a/docs/guides/testing-gpo.rst
+++ b/docs/guides/testing-gpo.rst
@@ -1,0 +1,66 @@
+Testing AD GPO HBAC
+====================
+
+:class:`~sssd_test_framework.roles.ad.AD.GPO`
+provides Group Policy Objects (GPO) management to configure GPO policies on AD. Allowing us
+to manage Host Based Access Control(HBAC) from the domain controller. GPOs are windows policies,
+consisting of computer and user configurations, registry keys, administrative template, security
+settings that are deployed to computers on the domain.
+
+.. code-block:: python
+    :caption: Test allow and deny users using GPOs
+
+    @pytest.mark.topology(KnownTopology.AD)
+    def test_ad__gpo_is_set_to_enforcing(client: Client, ad: AD):
+
+        allow_user = ad.user("allow_user").add()
+        deny_user = ad.user("deny_user").add()
+
+        ad.gpo("test policy").add().policy(
+            {
+                "SeInteractiveLogonRight": [allow_user, ad.group("Domain Admins")],
+                "SeRemoteInteractiveLogonRight": [allow_user, ad.group("Domain Admins")],
+                "SeDenyInteractiveLogonRight": [deny_user],
+                "SeRemoteDenyInteractiveLogonRight": [deny_user],
+            }
+        ).link()
+
+        client.sssd.domain["ad_gpo_access_control"] = "enforcing"
+        client.sssd.start()
+
+        assert client.auth.ssh.password(username="allow_user", password="Secret123")
+        assert not client.auth.ssh.password(username="deny_user", password="Secret123")
+
+Policies
+========
+SSSD uses the following security keys to manage access control.
+
+* SeInteractiveLogonRight: User or group is permitted to log in locally, TTY sessions and su (required).
+* SeRemoteInteractiveLogonRight: User or group is permitted to log in through SSH.
+* SeDenyInteractiveLogonRight: User or group is denied to log in locally. (required)
+* SeDenyRemoteInteractiveLogonRight: User or group is denied to log in through SSH.
+
+The *Remote* keys can be omitted, in which case the value is copied from the other similar key. The above
+policy examples are the same.
+
+.. code-block:: python
+    :caption: Remote keys
+
+        ad.gpo("test policy").add().policy(
+            {
+                "SeInteractiveLogonRight": [allow_user, ad.group("Domain Admins")],
+                "SeDenyInteractiveLogonRight": [deny_user],
+            }
+        ).link()
+
+.. note::
+   When configuring the policy, an Administrators group must be added to login.
+
+
+Inheritance
+===========
+GPOs are created and linked to a targets, sites, domains, or OUs. Local settings are processed first,
+then sites, domains and lastly OUs. Making GPOs linked to the OU take highest precedence. The values
+are keys, so the values will not be constructed from all the policies, it will be replaced by the
+policy with the higher priority. GPOs can be set to enforcing, which then no policy will override
+the enforced policy. Lastly the GPO does have an order, so the order can be defined manually.

--- a/sssd_test_framework/misc/__init__.py
+++ b/sssd_test_framework/misc/__init__.py
@@ -129,3 +129,27 @@ def parse_ldif(ldif: str) -> dict[str, dict[str, list[str]]]:
         output[result["dn"][0]] = result
 
     return output
+
+
+def attrs_to_hash(attrs: dict[str, Any]) -> str | None:
+    """
+    Convert attributes into an Powershell hash table records.
+
+    :param attrs: Attributes names and values.
+    :type attrs: dict[str, Any]
+    :return: Attributes in powershell hash record format.
+    :rtype: str | None
+    """
+    out = ""
+    for key, value in attrs.items():
+        if value is not None:
+            if isinstance(value, list):
+                values = [f'"{x}"' for x in value]
+                out += f'"{key}"={",".join(values)};'
+            else:
+                out += f'"{key}"="{value}";'
+
+    if not out:
+        return None
+
+    return "@{" + out.rstrip(";") + "}"

--- a/sssd_test_framework/utils/authentication.py
+++ b/sssd_test_framework/utils/authentication.py
@@ -19,8 +19,7 @@ __all__ = [
     "SudoAuthenticationUtils",
 ]
 
-
-DEFAULT_AUTHENTICATION_TIMEOUT: int = 20
+DEFAULT_AUTHENTICATION_TIMEOUT: int = 60
 """Default timeout for authentication failure."""
 
 
@@ -234,6 +233,7 @@ class SUAuthenticationUtils(MultihostUtility[MultihostHost]):
             expect {{
                 -re $prompt {{exitmsg "Password authentication successful" 0}}
                 "Authentication failure" {{exitmsg "Authentication failure" 1}}
+                "su: Permission denied" {{exitmsg "Permission denied" 2}}
                 timeout {{exitmsg "Unexpected output" 201}}
                 eof {{exitmsg "Unexpected end of file" 202}}
             }}
@@ -503,7 +503,7 @@ class SSHAuthenticationUtils(MultihostUtility[MultihostHost]):
             expect {{
                 -re $prompt {{exitmsg "Password authentication successful" 0}}
                 "{username}@localhost: Permission denied" {{exitmsg "Authentication failure" 1}}
-                "Connection closed by UNKNOWN port 65535" {{exitmsg "Connection closed" 2}}
+                "Connection closed by * port *" {{exitmsg "Connection closed" 2}}
                 timeout {{exitmsg "Unexpected output" 201}}
                 eof {{exitmsg "Unexpected end of file" 202}}
             }}

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,6 +9,7 @@ import pytest
 from sssd_test_framework.misc import (
     attrs_include_value,
     attrs_parse,
+    attrs_to_hash,
     parse_ldif,
     to_list,
     to_list_of_strings,
@@ -221,3 +222,16 @@ def test_to_list_without_none(value, expected):
 def test_parse_ldif(value, expected):
     value = textwrap.dedent(value).strip()
     assert parse_ldif(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (
+            {"key1": "value1", "key2": "value2 value2.1", "key3": "value3", "key4": "value4, value4.1"},
+            """@{"key1"="value1";"key2"="value2 value2.1";"key3"="value3";"key4"="value4, value4.1"}""",
+        )
+    ],
+)
+def test_attrs_to_hash(value, expected):
+    assert attrs_to_hash(value) == expected


### PR DESCRIPTION
- create gpo class to manage group policy objects; add(), link(), unlink(), permissions(), policy(), remove(), 
- moved attrs_to_hash to the roles class so other classes can inherit it
- updated adobject with get_sid method 
- added specific gpo backup and restore methods
- updated authentication expect catch for users not in a policy
- create ad computer class to move the computer object
- increased default authentication timeout in utils.authentication.py