### PR TITLE
SSH: Add the feature ssh-known-hosts-proxy

### DIFF
--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -44,6 +44,7 @@ class ClientHost(BaseBackupHost):
             [ -f "/usr/lib64/sssd/libsss_files.so" ] && echo "files-provider" || :
             [ -f "/usr/libexec/sssd/passkey_child" ] && echo "passkey" || :
             man sssd.conf | grep -q "user (string)" && echo "non-privileged" || :
+            /usr/bin/sss_ssh_knownhostsproxy -h 2>&1 | grep -q "Usage" && echo "ssh-known-hosts-proxy" || :
             """,
             log_level=SSHLog.Error,
         )
@@ -53,6 +54,7 @@ class ClientHost(BaseBackupHost):
             "files-provider": False,
             "passkey": False,
             "non-privileged": False,
+            "ssh-known-hosts-proxy": False,
         }
 
         self._features.update({k: True for k in result.stdout_lines})


### PR DESCRIPTION
This is required for the sss_ssh_knownhostsproxy tests modified in https://github.com/SSSD/sssd/pull/7223

This PR must be merged before the other one.

