### PR TITLE
utils: backup home directory when creating local user

### DIFF
--- a/sssd_test_framework/roles/client.py
+++ b/sssd_test_framework/roles/client.py
@@ -62,7 +62,7 @@ class Client(BaseLinuxRole[ClientHost]):
         Methods for testing automount.
         """
 
-        self.local: LocalUsersUtils = LocalUsersUtils(self.host)
+        self.local: LocalUsersUtils = LocalUsersUtils(self.host, self.fs)
         """
         Managing local users and groups.
         """

--- a/sssd_test_framework/utils/local_users.py
+++ b/sssd_test_framework/utils/local_users.py
@@ -6,6 +6,7 @@ import jc
 from pytest_mh import MultihostHost, MultihostUtility
 from pytest_mh.cli import CLIBuilder, CLIBuilderArgs
 from pytest_mh.ssh import SSHLog
+from pytest_mh.utils.fs import LinuxFileSystem
 
 __all__ = [
     "LocalGroup",
@@ -23,7 +24,7 @@ class LocalUsersUtils(MultihostUtility[MultihostHost]):
         All changes are automatically reverted when a test is finished.
     """
 
-    def __init__(self, host: MultihostHost) -> None:
+    def __init__(self, host: MultihostHost, fs: LinuxFileSystem) -> None:
         """
         :param host: Remote host instance.
         :type host: MultihostHost
@@ -31,6 +32,7 @@ class LocalUsersUtils(MultihostUtility[MultihostHost]):
         super().__init__(host)
 
         self.cli: CLIBuilder = CLIBuilder(host.ssh)
+        self.fs: LinuxFileSystem = fs
         self._users: list[str] = []
         self._groups: list[str] = []
 
@@ -155,6 +157,9 @@ class LocalUser(object):
         :return: Self.
         :rtype: LocalUser
         """
+        if home is not None:
+            self.util.fs.backup(home)
+
         args: CLIBuilderArgs = {
             "name": (self.util.cli.option.POSITIONAL, self.name),
             "uid": (self.util.cli.option.VALUE, uid),


### PR DESCRIPTION
useradd will create the home directory
usermod can change the home directory in /etc/passwd but it does not
move it
therefore we need to make sure that it is removed (or restored)
correctly