### PR TITLE
hosts: add ipa restart after restore

### DIFF
--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -126,3 +126,4 @@ class IPAHost(BaseDomainHost):
         self.ssh.exec(
             ["ipa-restore", "--unattended", "--password", self.adminpw, "--data", "--online", self._backup_location]
         )
+        self.ssh.exec(["systemctl", "restart", "ipa"])


### PR DESCRIPTION
IPA got stuck after restoring data in some cases, adding restart to alleviate the issue.