### PR TITLE
ci: Remove the broken 3.x from ci.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.x"]
+        python-version: ["3.10", ]
         upstream: ["upstream", "pypi"]
     runs-on: ubuntu-latest
     permissions:

--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,4 @@ commands =
 
 [gh]
 python =
-    3.x = {py3,lint,docs}{,-upstream}
     3.10 = {py310,lint,docs}{,-upstream}


### PR DESCRIPTION
The ci for 3.x is clearly broken and it is blocking other fixes.