### PR TITLE
topology: provision topologies if not already using per-topology setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.x"]
+        python-version: ["3.11", "3.x"]
         upstream: ["upstream", "pypi"]
     runs-on: ubuntu-latest
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Test framework for SSSD system tests"
 readme = "readme.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jc
 pytest
 python-ldap
-pytest-mh >= 1.0.11
+pytest-mh >= 1.0.14

--- a/sssd_test_framework/config.py
+++ b/sssd_test_framework/config.py
@@ -132,6 +132,11 @@ class SSSDTopologyMark(TopologyMark):
 
 class SSSDMultihostConfig(MultihostConfig):
     @property
+    def provisioned_topologies(self) -> list[str]:
+        out = self.confdict.get("provisioned_topologies", [])
+        return out if out is not None else []
+
+    @property
     def TopologyMarkClass(self) -> Type[TopologyMark]:
         return SSSDTopologyMark
 

--- a/sssd_test_framework/config.py
+++ b/sssd_test_framework/config.py
@@ -1,15 +1,133 @@
 from __future__ import annotations
 
-from typing import Any, Type
+from typing import Any, Mapping, Tuple, Type
 
-from pytest_mh import MultihostConfig, MultihostDomain, MultihostHost, MultihostRole, TopologyMark
-
-from .topology import SSSDTopologyMark
+import pytest
+from pytest_mh import (
+    MultihostConfig,
+    MultihostDomain,
+    MultihostHost,
+    MultihostRole,
+    Topology,
+    TopologyController,
+    TopologyMark,
+)
 
 __all__ = [
     "SSSDMultihostConfig",
     "SSSDMultihostDomain",
 ]
+
+
+class SSSDTopologyMark(TopologyMark):
+    """
+    Topology mark is used to describe test case requirements. It defines:
+
+    * **name**, that is used to identify topology in pytest output
+    * **topology** (:class:Topology) that is required to run the test
+    * **fixtures** that are available during the test run
+    * **domains** that will be automatically configured on the client
+
+    .. code-block:: python
+        :caption: Example usage
+
+        @pytest.mark.topology(name, topology, domains, fixture1='path1', fixture2='path2', ...)
+        def test_fixture_name(fixture1: BaseRole, fixture2: BaseRole, ...):
+            assert True
+
+    Fixture path points to a host in the multihost configuration and can be
+    either in the form of ``$domain-type.$role`` (all host of given role) or
+    ``$domain-type.$role[$index]`` (specific host on given index).
+
+    The ``name`` is visible in verbose pytest output after the test name, for example:
+
+    .. code-block:: console
+
+        tests/test_basic.py::test_case (topology-name) PASSED
+    """
+
+    def __init__(
+        self,
+        name: str,
+        topology: Topology,
+        *,
+        controller: TopologyController | None = None,
+        fixtures: dict[str, str] | None = None,
+        domains: dict[str, str] | None = None,
+    ) -> None:
+        """
+        :param name: Topology name used in pytest output.
+        :type name: str
+        :param topology: Topology required to run the test.
+        :type topology: Topology
+        :param controller: Topology controller, defaults to None
+        :type controller: TopologyController | None, optional
+        :param fixtures: Dynamically created fixtures available during the test run.
+        :type fixtures: dict[str, str] | None, optional
+        :param domains: Automatically created SSSD domains on client host
+        :type domains: dict[str, str] | None, optional
+        """
+        super().__init__(name, topology, controller=controller, fixtures=fixtures)
+
+        self.domains: dict[str, str] = domains if domains is not None else {}
+        """Map hosts to SSSD domains."""
+
+    def export(self) -> dict:
+        """
+        Export the topology mark into a dictionary object that can be easily
+        converted to JSON, YAML or other formats.
+
+        .. code-block:: python
+
+            {
+                'name': 'client',
+                'fixtures': { 'client': 'sssd.client[0]' },
+                'topology': [
+                    {
+                        'type': 'sssd',
+                        'hosts': { 'client': 1 }
+                    }
+                ],
+                'domains': { 'test': 'sssd.ldap[0]' },
+            }
+
+        :rtype: dict
+        """
+        d = super().export()
+        d["domains"] = self.domains
+
+        return d
+
+    @classmethod
+    def _CreateFromArgs(cls, item: pytest.Function, args: Tuple, kwargs: Mapping[str, Any]) -> TopologyMark:
+        """
+        Create :class:`TopologyMark` from pytest marker arguments.
+
+        .. warning::
+
+            This should only be called internally. You can inherit from
+            :class:`TopologyMark` and override this in order to add additional
+            attributes to the marker.
+
+        :param item: Pytest item.
+        :type item: pytest.Function
+        :raises ValueError: If the marker is invalid.
+        :return: Instance of TopologyMark.
+        :rtype: TopologyMark
+        """
+        # First three parameters are positional, the rest are keyword arguments.
+        if len(args) != 2 and len(args) != 3:
+            nodeid = item.parent.nodeid if item.parent is not None else ""
+            error = f"{nodeid}::{item.originalname}: invalid arguments for @pytest.mark.topology"
+            raise ValueError(error)
+
+        name = args[0]
+        topology = args[1]
+        domains = args[2] if len(args) == 3 else {}
+        controller = kwargs.get("controller", None)
+        fixtures = {k: str(v) for k, v in kwargs.get("fixtures", {}).items()}
+
+        return cls(name, topology, controller=controller, fixtures=fixtures, domains=domains)
 
 
 class SSSDMultihostConfig(MultihostConfig):

--- a/sssd_test_framework/hosts/ad.py
+++ b/sssd_test_framework/hosts/ad.py
@@ -38,6 +38,9 @@ class ADHost(BaseDomainHost):
 
         self._features: dict[str, bool] | None = None
 
+        self.adminpw: str = self.config.get("adminpw", "Secret123")
+        """Password of the Administrator user, defaults to ``Secret123``."""
+
         # Additional client configuration
         self.client.setdefault("id_provider", "ad")
         self.client.setdefault("access_provider", "ad")

--- a/sssd_test_framework/hosts/ad.py
+++ b/sssd_test_framework/hosts/ad.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import PureWindowsPath
 from typing import Any
 
+from pytest_mh.ssh import SSHLog
+
 from .base import BaseDomainHost
 
 __all__ = [
@@ -114,6 +116,8 @@ class ADHost(BaseDomainHost):
         :return: Backup data.
         :rtype: Any
         """
+        self.logger.info("Creating backup of Active Directory")
+
         result = self.ssh.run(
             rf"""
             $basedn = '{self.naming_context}'
@@ -146,7 +150,8 @@ class ADHost(BaseDomainHost):
             }}
 
             Write-Output $tmpdir.FullName
-            """
+            """,
+            log_level=SSHLog.Error,
         )
 
         return PureWindowsPath(result.stdout.strip())
@@ -178,6 +183,7 @@ class ADHost(BaseDomainHost):
             raise TypeError(f"Expected PureWindowsPath, got {type(backup_data)}")
 
         backup_path = str(backup_data)
+        self.logger.info(f"Restoring Active Directory from {backup_path}")
 
         self.ssh.run(
             rf"""
@@ -246,5 +252,6 @@ class ADHost(BaseDomainHost):
 
             # If we got here, make sure we exit with 0
             Exit 0
-            """
+            """,
+            log_level=SSHLog.Error,
         )

--- a/sssd_test_framework/hosts/ad.py
+++ b/sssd_test_framework/hosts/ad.py
@@ -95,6 +95,12 @@ class ADHost(BaseDomainHost):
     def disconnect(self) -> None:
         return
 
+    def start(self) -> None:
+        raise NotImplementedError("Starting Active Directory service is not implemented.")
+
+    def stop(self) -> None:
+        raise NotImplementedError("Stopping Active Directory service is not implemented.")
+
     def backup(self) -> Any:
         """
         Perform limited backup of the domain controller data. Content under

--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -58,12 +58,17 @@ class BaseBackupHost(BaseHost, ABC):
         """Backup data of vanilla state of this host."""
 
     def pytest_setup(self) -> None:
-        super().pytest_setup()
+        # Make sure required services are running
+        try:
+            self.start()
+        except NotImplementedError:
+            pass
+
+        # Create backup of initial state
         self.backup_data = self.backup()
 
     def pytest_teardown(self) -> None:
         self.remove_backup(self.backup_data)
-        super().pytest_teardown()
 
     def remove_backup(self, backup_data: Any | None) -> None:
         """
@@ -84,6 +89,24 @@ class BaseBackupHost(BaseHost, ABC):
             self.ssh.exec(["Remove-Item", "-Force", "-Recurse", path])
         else:
             self.ssh.exec(["rm", "-fr", path])
+
+    @abstractmethod
+    def start(self) -> None:
+        """
+        Start required services.
+
+        :raises NotImplementedError: If start operation is not supported.
+        """
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """
+        Stop required services.
+
+        :raises NotImplementedError: If stop operation is not supported.
+        """
+        pass
 
     @abstractmethod
     def backup(self) -> Any:

--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -14,6 +14,7 @@ from pytest_mh.utils.fs import LinuxFileSystem
 from pytest_mh.utils.services import SystemdServices
 
 from ..config import SSSDMultihostDomain
+from ..misc import retry
 
 __all__ = [
     "BaseHost",
@@ -216,6 +217,7 @@ class BaseLDAPDomainHost(BaseDomainHost):
         self.__naming_context: str | None = None
 
     @property
+    @retry(on=ldap.SERVER_DOWN)
     def conn(self) -> ReconnectLDAPObject:
         """
         LDAP connection (``python-ldap`` library).

--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -10,6 +10,8 @@ import ldap
 from ldap.ldapobject import ReconnectLDAPObject
 from pytest_mh import MultihostHost
 from pytest_mh.ssh import SSHPowerShellProcess
+from pytest_mh.utils.fs import LinuxFileSystem
+from pytest_mh.utils.services import SystemdServices
 
 from ..config import SSSDMultihostDomain
 
@@ -255,3 +257,17 @@ class BaseLDAPDomainHost(BaseDomainHost):
         :rtype: dict[str, dict[str, list[bytes]]]
         """
         return dict((dn, attrs) for dn, attrs in result if dn is not None)
+
+
+class BaseLinuxHost(MultihostHost[SSSDMultihostDomain]):
+    """
+    Base Linux host.
+
+    Adds linux specific reentrant utilities.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.fs: LinuxFileSystem = LinuxFileSystem(self)
+        self.svc: SystemdServices = SystemdServices(self)

--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -63,13 +63,6 @@ class BaseBackupHost(BaseHost, ABC):
         self.remove_backup(self.backup_data)
         super().pytest_teardown()
 
-    def teardown(self) -> None:
-        """
-        Restore to vanilla state after each test.
-        """
-        self.restore(self.backup_data)
-        return super().teardown()
-
     def remove_backup(self, backup_data: Any | None) -> None:
         """
         Remove backup data from the host.

--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -95,6 +95,8 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
             }
 
             path=`mktemp -d`
+            backup /etc/krb5.conf "$path/krb5.conf"
+            backup /etc/krb5.keytab "$path/krb5.keytab"
             backup /etc/sssd "$path/config"
             backup /var/log/sssd "$path/logs"
             backup /var/lib/sss "$path/lib"
@@ -134,6 +136,8 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
             }}
 
             rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd
+            restore "{backup_path}/krb5.conf" /etc/krb5.conf
+            restore "{backup_path}/krb5.keytab" /etc/krb5.keytab
             restore "{backup_path}/config" /etc/sssd
             restore "{backup_path}/logs" /var/log/sssd
             restore "{backup_path}/lib" /var/lib/sss

--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -63,6 +63,18 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
 
         return self._features
 
+    def start(self) -> None:
+        """
+        Not supported.
+
+        :raises NotImplementedError: _description_
+        """
+        # SSSD might not be configured properly at this time. We start and stop SSSD in tests.
+        raise NotImplementedError("Starting Active Directory service is not implemented.")
+
+    def stop(self) -> None:
+        self.svc.stop("sssd.service")
+
     def backup(self) -> Any:
         """
         Backup all SSSD data.

--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from pytest_mh.ssh import SSHLog
 
-from .base import BaseBackupHost
+from .base import BaseBackupHost, BaseLinuxHost
 
 __all__ = [
     "ClientHost",
 ]
 
 
-class ClientHost(BaseBackupHost):
+class ClientHost(BaseBackupHost, BaseLinuxHost):
     """
     SSSD client host object.
 

--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from pytest_mh.ssh import SSHLog
 
-from .base import BaseDomainHost
+from .base import BaseDomainHost, BaseLinuxHost
 
 __all__ = [
     "IPAHost",
 ]
 
 
-class IPAHost(BaseDomainHost):
+class IPAHost(BaseDomainHost, BaseLinuxHost):
     """
     IPA host object.
 

--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -66,11 +66,6 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
         if "realm" not in self.config:
             self.realm = self.domain.upper()
 
-    def setup(self) -> None:
-        # Make sure ipa is running for each test
-        self.ssh.run("ipactl start")
-        super().setup()
-
     @property
     def features(self) -> dict[str, bool]:
         """
@@ -109,6 +104,12 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
         Obtain ``admin`` user Kerberos TGT.
         """
         self.ssh.exec(["kinit", "admin"], input=self.adminpw)
+
+    def start(self) -> None:
+        self.svc.start("ipa.service")
+
+    def stop(self) -> None:
+        self.svc.stop("ipa.service")
 
     def backup(self) -> Any:
         """

--- a/sssd_test_framework/hosts/kdc.py
+++ b/sssd_test_framework/hosts/kdc.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from .base import BaseDomainHost
+from .base import BaseDomainHost, BaseLinuxHost
 
 __all__ = [
     "KDCHost",
 ]
 
 
-class KDCHost(BaseDomainHost):
+class KDCHost(BaseDomainHost, BaseLinuxHost):
     """
     Kerberos KDC server host object.
 

--- a/sssd_test_framework/hosts/kdc.py
+++ b/sssd_test_framework/hosts/kdc.py
@@ -45,6 +45,12 @@ class KDCHost(BaseDomainHost, BaseLinuxHost):
 
         self.client["auth_provider"] = "krb5"
 
+    def start(self) -> None:
+        self.svc.start("krb5kdc.service")
+
+    def stop(self) -> None:
+        self.svc.stop("krb5kdc.service")
+
     def backup(self) -> Any:
         """
         Backup KDC server.

--- a/sssd_test_framework/hosts/kdc.py
+++ b/sssd_test_framework/hosts/kdc.py
@@ -52,8 +52,15 @@ class KDCHost(BaseDomainHost):
         :return: Backup data.
         :rtype: Any
         """
-        self.ssh.run('kdb5_util dump /tmp/mh.kdc.kdb.backup && rm -f "/tmp/mh.kdc.kdb.backup.dump_ok"')
-        return PurePosixPath("/tmp/mh.kdc.kdb.backup")
+        result = self.ssh.run(
+            """
+            set -e
+            path=`mktemp`
+            kdb5_util dump $path && rm -f "$path.dump_ok"
+            echo $path
+            """
+        )
+        return PurePosixPath(result.stdout_lines[-1].strip())
 
     def restore(self, backup_data: Any | None) -> None:
         """

--- a/sssd_test_framework/hosts/keycloak.py
+++ b/sssd_test_framework/hosts/keycloak.py
@@ -8,14 +8,14 @@ from typing import Any
 
 from pytest_mh.ssh import SSHProcessError
 
-from .base import BaseDomainHost
+from .base import BaseDomainHost, BaseLinuxHost
 
 __all__ = [
     "KeycloakHost",
 ]
 
 
-class KeycloakHost(BaseDomainHost):
+class KeycloakHost(BaseDomainHost, BaseLinuxHost):
     """
     Keycloak host object.
 

--- a/sssd_test_framework/hosts/ldap.py
+++ b/sssd_test_framework/hosts/ldap.py
@@ -7,14 +7,14 @@ from typing import Any
 import ldap
 from pytest_mh.ssh import SSHLog
 
-from .base import BaseLDAPDomainHost
+from .base import BaseLDAPDomainHost, BaseLinuxHost
 
 __all__ = [
     "LDAPHost",
 ]
 
 
-class LDAPHost(BaseLDAPDomainHost):
+class LDAPHost(BaseLDAPDomainHost, BaseLinuxHost):
     """
     LDAP host object.
 

--- a/sssd_test_framework/hosts/ldap.py
+++ b/sssd_test_framework/hosts/ldap.py
@@ -91,6 +91,8 @@ class LDAPHost(BaseLDAPDomainHost, BaseLinuxHost):
         :return: Backup data.
         :rtype: Any
         """
+        self.logger.info("Creating backup of LDAP server")
+
         data = self.conn.search_s(self.naming_context, ldap.SCOPE_SUBTREE)
         config = self.conn.search_s("cn=config", ldap.SCOPE_BASE)
         nc = self.conn.search_s(self.naming_context, ldap.SCOPE_BASE, attrlist=["aci"])
@@ -116,6 +118,8 @@ class LDAPHost(BaseLDAPDomainHost, BaseLinuxHost):
         """
         if backup_data is None:
             return
+
+        self.logger.info("Restoring LDAP server from memory")
 
         if not isinstance(backup_data, dict):
             raise TypeError(f"Expected dict, got {type(backup_data)}")

--- a/sssd_test_framework/hosts/nfs.py
+++ b/sssd_test_framework/hosts/nfs.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from .base import BaseBackupHost
+from .base import BaseBackupHost, BaseLinuxHost
 
 __all__ = [
     "NFSHost",
 ]
 
 
-class NFSHost(BaseBackupHost):
+class NFSHost(BaseBackupHost, BaseLinuxHost):
     """
     NFS server host object.
 

--- a/sssd_test_framework/hosts/nfs.py
+++ b/sssd_test_framework/hosts/nfs.py
@@ -41,6 +41,12 @@ class NFSHost(BaseBackupHost, BaseLinuxHost):
         self.exports_dir: str = self.config.get("exports_dir", "/exports").rstrip("/")
         """Top level NFS exports directory, defaults to ``/exports``."""
 
+    def start(self) -> None:
+        self.svc.start("nfs-server.service")
+
+    def stop(self) -> None:
+        self.svc.stop("nfs-server.service")
+
     def backup(self) -> Any:
         """
         Backup NFS server.

--- a/sssd_test_framework/hosts/samba.py
+++ b/sssd_test_framework/hosts/samba.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from .base import BaseLDAPDomainHost
+from .base import BaseLDAPDomainHost, BaseLinuxHost
 
 __all__ = [
     "SambaHost",
 ]
 
 
-class SambaHost(BaseLDAPDomainHost):
+class SambaHost(BaseLDAPDomainHost, BaseLinuxHost):
     """
     Samba host object.
 

--- a/sssd_test_framework/hosts/samba.py
+++ b/sssd_test_framework/hosts/samba.py
@@ -28,6 +28,9 @@ class SambaHost(BaseLDAPDomainHost, BaseLinuxHost):
 
         self._features: dict[str, bool] | None = None
 
+        self.adminpw: str = self.config.get("adminpw", self.bindpw)
+        """Password of the admin user, defaults to value of ``bindpw``."""
+
         # Additional client configuration
         self.client.setdefault("id_provider", "ad")
         self.client.setdefault("access_provider", "ad")

--- a/sssd_test_framework/roles/base.py
+++ b/sssd_test_framework/roles/base.py
@@ -128,12 +128,12 @@ class BaseLinuxRole(BaseRole[HostType]):
         Systemd service management.
         """
 
-        self.firewall: Firewalld = Firewalld(self.host)
+        self.firewall: Firewalld = Firewalld(self.host).postpone_setup()
         """
         Configure firewall using firewalld.
         """
 
-        self.tc: LinuxTrafficControl = LinuxTrafficControl(self.host)
+        self.tc: LinuxTrafficControl = LinuxTrafficControl(self.host).postpone_setup()
         """
         Traffic control manipulation.
         """
@@ -191,7 +191,7 @@ class BaseWindowsRole(BaseRole[HostType]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.firewall: WindowsFirewall = WindowsFirewall(self.host)
+        self.firewall: WindowsFirewall = WindowsFirewall(self.host).postpone_setup()
         """
         Configure Windows firewall.
         """

--- a/sssd_test_framework/roles/base.py
+++ b/sssd_test_framework/roles/base.py
@@ -17,7 +17,6 @@ from ..hosts.base import BaseHost, BaseLDAPDomainHost
 from ..utils.authentication import AuthenticationUtils
 from ..utils.authselect import AuthselectUtils
 from ..utils.ldap import LDAPUtils
-from ..utils.pam import PAMUtils
 from ..utils.sshd import SSHDUtils
 from ..utils.tools import LinuxToolsUtils
 
@@ -146,11 +145,6 @@ class BaseLinuxRole(BaseRole[HostType]):
         self.auth: AuthenticationUtils = AuthenticationUtils(self.host, self.fs)
         """
         Authentication helpers.
-        """
-
-        self.pam: PAMUtils = PAMUtils(self.host, self.fs)
-        """
-        Configuring various PAM modules.
         """
 
         self.journald: JournaldUtils = JournaldUtils(self.host)

--- a/sssd_test_framework/roles/ipa.py
+++ b/sssd_test_framework/roles/ipa.py
@@ -1108,7 +1108,6 @@ class IPASudoRule(IPAObject):
         :rtype: IPASudoRule
         """
         self.delete()
-        print(self.__rule)
         self.add(
             user=user if user is not None else self.__rule.get("user", None),
             host=host if host is not None else self.__rule.get("host", None),

--- a/sssd_test_framework/topology.py
+++ b/sssd_test_framework/topology.py
@@ -8,6 +8,15 @@ from typing import final
 from pytest_mh import KnownTopologyBase, KnownTopologyGroupBase, Topology, TopologyDomain
 
 from .config import SSSDTopologyMark
+from .topology_controllers import (
+    ADTopologyController,
+    ClientTopologyController,
+    IPATopologyController,
+    IPATrustADTopologyController,
+    IPATrustSambaTopologyController,
+    LDAPTopologyController,
+    SambaTopologyController,
+)
 
 __all__ = [
     "KnownTopology",
@@ -34,6 +43,7 @@ class KnownTopology(KnownTopologyBase):
     Client = SSSDTopologyMark(
         name="client",
         topology=Topology(TopologyDomain("sssd", client=1, kdc=1)),
+        controller=ClientTopologyController(),
         fixtures=dict(client="sssd.client[0]", kdc="sssd.kdc[0]"),
     )
     """
@@ -43,6 +53,7 @@ class KnownTopology(KnownTopologyBase):
     LDAP = SSSDTopologyMark(
         name="ldap",
         topology=Topology(TopologyDomain("sssd", client=1, ldap=1, nfs=1, kdc=1)),
+        controller=LDAPTopologyController(),
         domains=dict(test="sssd.ldap[0]"),
         fixtures=dict(
             client="sssd.client[0]", ldap="sssd.ldap[0]", provider="sssd.ldap[0]", nfs="sssd.nfs[0]", kdc="sssd.kdc[0]"
@@ -55,6 +66,7 @@ class KnownTopology(KnownTopologyBase):
     IPA = SSSDTopologyMark(
         name="ipa",
         topology=Topology(TopologyDomain("sssd", client=1, ipa=1, nfs=1)),
+        controller=IPATopologyController(),
         domains=dict(test="sssd.ipa[0]"),
         fixtures=dict(client="sssd.client[0]", ipa="sssd.ipa[0]", provider="sssd.ipa[0]", nfs="sssd.nfs[0]"),
     )
@@ -65,6 +77,7 @@ class KnownTopology(KnownTopologyBase):
     AD = SSSDTopologyMark(
         name="ad",
         topology=Topology(TopologyDomain("sssd", client=1, ad=1, nfs=1)),
+        controller=ADTopologyController(),
         domains=dict(test="sssd.ad[0]"),
         fixtures=dict(client="sssd.client[0]", ad="sssd.ad[0]", provider="sssd.ad[0]", nfs="sssd.nfs[0]"),
     )
@@ -75,6 +88,7 @@ class KnownTopology(KnownTopologyBase):
     Samba = SSSDTopologyMark(
         name="samba",
         topology=Topology(TopologyDomain("sssd", client=1, samba=1, nfs=1)),
+        controller=SambaTopologyController(),
         domains={"test": "sssd.samba[0]"},
         fixtures=dict(client="sssd.client[0]", samba="sssd.samba[0]", provider="sssd.samba[0]", nfs="sssd.nfs[0]"),
     )
@@ -85,6 +99,7 @@ class KnownTopology(KnownTopologyBase):
     IPATrustAD = SSSDTopologyMark(
         name="ipa-trust-ad",
         topology=Topology(TopologyDomain("sssd", client=1, ipa=1, ad=1)),
+        controller=IPATrustADTopologyController(),
         domains=dict(test="sssd.ipa[0]"),
         fixtures=dict(client="sssd.client[0]", ipa="sssd.ipa[0]", ad="sssd.ad[0]", trusted="sssd.ad[0]"),
     )
@@ -95,6 +110,7 @@ class KnownTopology(KnownTopologyBase):
     IPATrustSamba = SSSDTopologyMark(
         name="ipa-trust-samba",
         topology=Topology(TopologyDomain("sssd", client=1, ipa=1, samba=1)),
+        controller=IPATrustSambaTopologyController(),
         domains=dict(test="sssd.ipa[0]"),
         fixtures=dict(client="sssd.client[0]", ipa="sssd.ipa[0]", samba="sssd.samba[0]", trusted="sssd.samba[0]"),
     )

--- a/sssd_test_framework/topology.py
+++ b/sssd_test_framework/topology.py
@@ -3,133 +3,16 @@
 from __future__ import annotations
 
 from enum import unique
-from typing import Any, Mapping, Tuple, final
+from typing import final
 
-import pytest
-from pytest_mh import (
-    KnownTopologyBase,
-    KnownTopologyGroupBase,
-    Topology,
-    TopologyController,
-    TopologyDomain,
-    TopologyMark,
-)
+from pytest_mh import KnownTopologyBase, KnownTopologyGroupBase, Topology, TopologyDomain
+
+from .config import SSSDTopologyMark
 
 __all__ = [
     "KnownTopology",
     "KnownTopologyGroup",
 ]
-
-
-class SSSDTopologyMark(TopologyMark):
-    """
-    Topology mark is used to describe test case requirements. It defines:
-
-    * **name**, that is used to identify topology in pytest output
-    * **topology** (:class:Topology) that is required to run the test
-    * **fixtures** that are available during the test run
-    * **domains** that will be automatically configured on the client
-
-    .. code-block:: python
-        :caption: Example usage
-
-        @pytest.mark.topology(name, topology, domains, fixture1='path1', fixture2='path2', ...)
-        def test_fixture_name(fixture1: BaseRole, fixture2: BaseRole, ...):
-            assert True
-
-    Fixture path points to a host in the multihost configuration and can be
-    either in the form of ``$domain-type.$role`` (all host of given role) or
-    ``$domain-type.$role[$index]`` (specific host on given index).
-
-    The ``name`` is visible in verbose pytest output after the test name, for example:
-
-    .. code-block:: console
-
-        tests/test_basic.py::test_case (topology-name) PASSED
-    """
-
-    def __init__(
-        self,
-        name: str,
-        topology: Topology,
-        *,
-        controller: TopologyController | None = None,
-        fixtures: dict[str, str] | None = None,
-        domains: dict[str, str] | None = None,
-    ) -> None:
-        """
-        :param name: Topology name used in pytest output.
-        :type name: str
-        :param topology: Topology required to run the test.
-        :type topology: Topology
-        :param controller: Topology controller, defaults to None
-        :type controller: TopologyController | None, optional
-        :param fixtures: Dynamically created fixtures available during the test run.
-        :type fixtures: dict[str, str] | None, optional
-        :param domains: Automatically created SSSD domains on client host
-        :type domains: dict[str, str] | None, optional
-        """
-        super().__init__(name, topology, controller=controller, fixtures=fixtures)
-
-        self.domains: dict[str, str] = domains if domains is not None else {}
-        """Map hosts to SSSD domains."""
-
-    def export(self) -> dict:
-        """
-        Export the topology mark into a dictionary object that can be easily
-        converted to JSON, YAML or other formats.
-
-        .. code-block:: python
-
-            {
-                'name': 'client',
-                'fixtures': { 'client': 'sssd.client[0]' },
-                'topology': [
-                    {
-                        'type': 'sssd',
-                        'hosts': { 'client': 1 }
-                    }
-                ],
-                'domains': { 'test': 'sssd.ldap[0]' },
-            }
-
-        :rtype: dict
-        """
-        d = super().export()
-        d["domains"] = self.domains
-
-        return d
-
-    @classmethod
-    def _CreateFromArgs(cls, item: pytest.Function, args: Tuple, kwargs: Mapping[str, Any]) -> TopologyMark:
-        """
-        Create :class:`TopologyMark` from pytest marker arguments.
-
-        .. warning::
-
-            This should only be called internally. You can inherit from
-            :class:`TopologyMark` and override this in order to add additional
-            attributes to the marker.
-
-        :param item: Pytest item.
-        :type item: pytest.Function
-        :raises ValueError: If the marker is invalid.
-        :return: Instance of TopologyMark.
-        :rtype: TopologyMark
-        """
-        # First three parameters are positional, the rest are keyword arguments.
-        if len(args) != 2 and len(args) != 3:
-            nodeid = item.parent.nodeid if item.parent is not None else ""
-            error = f"{nodeid}::{item.originalname}: invalid arguments for @pytest.mark.topology"
-            raise ValueError(error)
-
-        name = args[0]
-        topology = args[1]
-        domains = args[2] if len(args) == 3 else {}
-        controller = kwargs.get("controller", None)
-        fixtures = {k: str(v) for k, v in kwargs.get("fixtures", {}).items()}
-
-        return cls(name, topology, controller=controller, fixtures=fixtures, domains=domains)
 
 
 @final

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pytest_mh import TopologyController
+
+from .hosts.base import BaseBackupHost
+
+__all__ = [
+    "LDAPTopologyController",
+    "IPATopologyController",
+    "ADTopologyController",
+    "SambaTopologyController",
+    "IPATrustADTopologyController",
+    "IPATrustSambaTopologyController",
+]
+
+
+class BackupTopologyController(TopologyController):
+    """
+    Run "restore" method on all hosts that inherit from BaseBackupHost.
+    """
+
+    def teardown(self, **kwargs) -> None:
+        errors = []
+        for host in set(kwargs.values()):
+            if not isinstance(host, BaseBackupHost):
+                continue
+
+            try:
+                host.restore(host.backup_data)
+            except Exception as e:
+                errors.append(e)
+
+        if errors:
+            raise ExceptionGroup("Some hosts failed to restore to original state", errors)
+
+
+class ClientTopologyController(BackupTopologyController):
+    """
+    Client Topology Controller.
+    """
+
+    pass
+
+
+class LDAPTopologyController(BackupTopologyController):
+    """
+    LDAP Topology Controller.
+    """
+
+    pass
+
+
+class IPATopologyController(BackupTopologyController):
+    """
+    IPA Topology Controller.
+    """
+
+    pass
+
+
+class ADTopologyController(BackupTopologyController):
+    """
+    AD Topology Controller.
+    """
+
+    pass
+
+
+class SambaTopologyController(BackupTopologyController):
+    """
+    Samba Topology Controller.
+    """
+
+    pass
+
+
+class IPATrustADTopologyController(BackupTopologyController):
+    """
+    IPA trust AD Topology Controller.
+    """
+
+    pass
+
+
+class IPATrustSambaTopologyController(BackupTopologyController):
+    """
+    IPA trust Samba Topology Controller.
+    """
+
+    pass

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+from functools import partial, wraps
+from typing import Any
+
 from pytest_mh import TopologyController
 
+from .config import SSSDMultihostConfig
+from .hosts.ad import ADHost
 from .hosts.base import BaseBackupHost
+from .hosts.client import ClientHost
+from .hosts.ipa import IPAHost
+from .hosts.nfs import NFSHost
+from .hosts.samba import SambaHost
 
 __all__ = [
     "LDAPTopologyController",
@@ -14,24 +23,90 @@ __all__ = [
 ]
 
 
-class BackupTopologyController(TopologyController):
+def restore_vanilla_on_error(method):
     """
-    Run "restore" method on all hosts that inherit from BaseBackupHost.
+    Restore or hosts to its original state if an exception occurs
+    during method execution.
+
+    :param method: Method to decorate.
+    :type method: _type_
+    :return: _description_
+    :rtype: _type_
     """
 
-    def teardown(self, **kwargs) -> None:
+    @wraps(method)
+    def wrapper(self: BackupTopologyController, *args, **kwargs):
+        try:
+            return self._invoke_with_args(partial(method, self))
+        except Exception:
+            self.restore_vanilla()
+            raise
+
+    return wrapper
+
+
+class BackupTopologyController(TopologyController[SSSDMultihostConfig]):
+    """
+    Provide basic restore functionality for topologies.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.backup_data: dict[BaseBackupHost, Any | None] = {}
+        self.provisioned: bool = False
+
+    def _init(self, *args, **kwargs):
+        super()._init(*args, **kwargs)
+        self.provisioned = self.name in self.multihost.provisioned_topologies
+
+    def restore(self, hosts: dict[BaseBackupHost, Any | None]) -> None:
         errors = []
-        for host in set(kwargs.values()):
+        for host, backup_data in hosts.items():
             if not isinstance(host, BaseBackupHost):
                 continue
 
             try:
-                host.restore(host.backup_data)
+                host.restore(backup_data)
             except Exception as e:
                 errors.append(e)
 
         if errors:
             raise ExceptionGroup("Some hosts failed to restore to original state", errors)
+
+    def restore_vanilla(self) -> None:
+        restore_data: dict[BaseBackupHost, Any | None] = {}
+
+        for host in self.hosts:
+            if not isinstance(host, BaseBackupHost):
+                continue
+
+            restore_data[host] = host.backup_data
+
+        self.restore(restore_data)
+
+    def topology_teardown(self) -> None:
+        if self.provisioned:
+            return
+
+        try:
+            for host, backup_data in self.backup_data.items():
+                if not isinstance(host, BaseBackupHost):
+                    continue
+
+                host.remove_backup(backup_data)
+        except Exception:
+            # This is not that important, we can just ignore
+            pass
+
+        self.restore_vanilla()
+
+    def teardown(self) -> None:
+        if self.provisioned:
+            self.restore_vanilla()
+            return
+
+        self.restore(self.backup_data)
 
 
 class ClientTopologyController(BackupTopologyController):
@@ -39,7 +114,11 @@ class ClientTopologyController(BackupTopologyController):
     Client Topology Controller.
     """
 
-    pass
+    def topology_teardown(self) -> None:
+        pass
+
+    def teardown(self) -> None:
+        self.restore_vanilla()
 
 
 class LDAPTopologyController(BackupTopologyController):
@@ -47,7 +126,11 @@ class LDAPTopologyController(BackupTopologyController):
     LDAP Topology Controller.
     """
 
-    pass
+    def topology_teardown(self) -> None:
+        pass
+
+    def teardown(self) -> None:
+        self.restore_vanilla()
 
 
 class IPATopologyController(BackupTopologyController):
@@ -55,7 +138,29 @@ class IPATopologyController(BackupTopologyController):
     IPA Topology Controller.
     """
 
-    pass
+    @restore_vanilla_on_error
+    def topology_setup(self, client: ClientHost, ipa: IPAHost, nfs: NFSHost) -> None:
+        if self.provisioned:
+            self.logger.info(f"Topology '{self.name}' is already provisioned")
+            return
+
+        self.logger.info(f"Enrolling {client.hostname} into {ipa.domain}")
+
+        # Remove any existing Kerberos configuration and keytab
+        client.fs.rm("/etc/krb5.conf")
+        client.fs.rm("/etc/krb5.keytab")
+
+        # Backup ipa-client-install files
+        client.fs.backup("/etc/ipa")
+        client.fs.backup("/var/lib/ipa-client")
+
+        # Join ipa domain
+        client.ssh.exec(["realm", "join", ipa.domain], input=ipa.adminpw)
+
+        # Backup so we can restore to this state after each test
+        self.backup_data[ipa] = ipa.backup()
+        self.backup_data[client] = client.backup()
+        self.backup_data[nfs] = nfs.backup()
 
 
 class ADTopologyController(BackupTopologyController):
@@ -63,10 +168,28 @@ class ADTopologyController(BackupTopologyController):
     AD Topology Controller.
     """
 
-    pass
+    @restore_vanilla_on_error
+    def topology_setup(self, client: ClientHost, provider: ADHost | SambaHost, nfs: NFSHost) -> None:
+        if self.provisioned:
+            self.logger.info(f"Topology '{self.name}' is already provisioned")
+            return
+
+        self.logger.info(f"Enrolling {client.hostname} into {provider.domain}")
+
+        # Remove any existing Kerberos configuration and keytab
+        client.fs.rm("/etc/krb5.conf")
+        client.fs.rm("/etc/krb5.keytab")
+
+        # Join AD domain
+        client.ssh.exec(["realm", "join", provider.domain], input=provider.adminpw)
+
+        # Backup so we can restore to this state after each test
+        self.backup_data[provider] = provider.backup()
+        self.backup_data[client] = client.backup()
+        self.backup_data[nfs] = nfs.backup()
 
 
-class SambaTopologyController(BackupTopologyController):
+class SambaTopologyController(ADTopologyController):
     """
     Samba Topology Controller.
     """
@@ -79,10 +202,42 @@ class IPATrustADTopologyController(BackupTopologyController):
     IPA trust AD Topology Controller.
     """
 
-    pass
+    @restore_vanilla_on_error
+    def topology_setup(self, client: ClientHost, ipa: IPAHost, trusted: ADHost | SambaHost) -> None:
+        if self.provisioned:
+            self.logger.info(f"Topology '{self.name}' is already provisioned")
+            return
+
+        # Create trust
+        self.logger.info(f"Establishing trust between {ipa.domain} and {trusted.domain}")
+        ipa.kinit()
+        ipa.ssh.exec(
+            ["ipa", "trust-add", trusted.domain, "--admin", "Administrator", "--password"],
+            input=trusted.adminpw,
+        )
+
+        # Do not enroll client into IPA domain if it is already joined
+        if "ipa" not in self.multihost.provisioned_topologies:
+            self.logger.info(f"Enrolling {client.hostname} into {ipa.domain}")
+
+            # Remove any existing Kerberos configuration and keytab
+            client.fs.rm("/etc/krb5.conf")
+            client.fs.rm("/etc/krb5.keytab")
+
+            # Backup ipa-client-install files
+            client.fs.backup("/etc/ipa")
+            client.fs.backup("/var/lib/ipa-client")
+
+            # Join IPA domain)
+            client.ssh.exec(["realm", "join", ipa.domain], input=ipa.adminpw)
+
+        # Backup so we can restore to this state after each test
+        self.backup_data[ipa] = ipa.backup()
+        self.backup_data[trusted] = trusted.backup()
+        self.backup_data[client] = client.backup()
 
 
-class IPATrustSambaTopologyController(BackupTopologyController):
+class IPATrustSambaTopologyController(IPATrustADTopologyController):
     """
     IPA trust Samba Topology Controller.
     """

--- a/sssd_test_framework/utils/sshd.py
+++ b/sssd_test_framework/utils/sshd.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pytest_mh import MultihostHost, MultihostUtility
+from pytest_mh import MultihostHost, MultihostUtility, mh_utility_postpone_setup
 from pytest_mh.ssh import SSHProcessResult
 from pytest_mh.utils.fs import LinuxFileSystem
 from pytest_mh.utils.services import SystemdServices
@@ -12,6 +12,7 @@ __all__ = [
 ]
 
 
+@mh_utility_postpone_setup
 class SSHDUtils(MultihostUtility[MultihostHost]):
     """
     Managing global and server SSH configuration files.
@@ -61,13 +62,13 @@ class SSHDUtils(MultihostUtility[MultihostHost]):
         self.args: str = f'--transform "sshd.lns incl {self.file}"'
         self.cmd: str = ""
 
-    def setup_when_used(self) -> None:
-        super().setup_when_used()
+    def setup(self) -> None:
+        super().setup()
         self.fs.backup(self.file)
 
-    def teardown_when_used(self) -> None:
-        super().teardown_when_used()
+    def teardown(self) -> None:
         self.svc.reload("sshd")
+        super().teardown()
 
     def config_read(self) -> str:
         """

--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -88,7 +88,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         Shortcuts to SSSD log paths.
         """
 
-    def setup_when_used(self) -> None:
+    def setup(self) -> None:
         """
         Setup SSSD on the host.
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+import time
 
 import pytest
 
@@ -11,6 +12,7 @@ from sssd_test_framework.misc import (
     attrs_parse,
     attrs_to_hash,
     parse_ldif,
+    retry,
     to_list,
     to_list_of_strings,
     to_list_without_none,
@@ -235,3 +237,95 @@ def test_parse_ldif(value, expected):
 )
 def test_attrs_to_hash(value, expected):
     assert attrs_to_hash(value) == expected
+
+
+def test_retry__all_exceptions():
+    rounds = []
+
+    @retry(max_retries=5, delay=0)
+    def test():
+        if len(rounds) < 4:
+            rounds.append(True)
+            raise Exception("My exception")
+
+        return len(rounds)
+
+    assert test() == 4
+
+
+def test_retry__single_exception__positive():
+    rounds = []
+
+    @retry(max_retries=5, delay=0, on=ValueError)
+    def test():
+        if len(rounds) < 4:
+            rounds.append(True)
+            raise ValueError("My exception")
+
+        return len(rounds)
+
+    assert test() == 4
+
+
+def test_retry__single_exception__negative():
+    rounds = []
+
+    @retry(max_retries=5, delay=0, on=ValueError)
+    def test():
+        if len(rounds) < 4:
+            rounds.append(True)
+            raise KeyError("My exception")
+
+        return len(rounds)
+
+    with pytest.raises(KeyError):
+        test()
+
+
+def test_retry__multiple_exceptions__positive():
+    rounds = []
+
+    @retry(max_retries=5, delay=0, on=(ValueError, KeyError))
+    def test():
+        if len(rounds) < 2:
+            rounds.append(True)
+            raise KeyError("My exception")
+
+        if len(rounds) < 4:
+            rounds.append(True)
+            raise ValueError("My exception")
+
+        return len(rounds)
+
+    assert test() == 4
+
+
+def test_retry__multiple_exceptions__negative():
+    rounds = []
+
+    @retry(max_retries=5, delay=0, on=(TypeError, KeyError))
+    def test():
+        if len(rounds) < 2:
+            rounds.append(True)
+            raise KeyError("My exception")
+
+        if len(rounds) < 4:
+            rounds.append(True)
+            raise ValueError("My exception")
+
+        return len(rounds)
+
+    with pytest.raises(ValueError):
+        test()
+
+
+def test_retry__delay():
+    @retry(max_retries=5, delay=1)
+    def test():
+        raise ValueError("My exception")
+
+    now = time.time()
+    with pytest.raises(ValueError):
+        test()
+
+    assert time.time() - now >= 5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py3,py310,lint,docs}{,-upstream}
+envlist = {py3,py311,lint,docs}{,-upstream}
 
 [testenv]
 deps =
@@ -36,4 +36,4 @@ commands =
 [gh]
 python =
     3.x = {py3,lint,docs}{,-upstream}
-    3.10 = {py310,lint,docs}{,-upstream}
+    3.11 = {py311,lint,docs}{,-upstream}


### PR DESCRIPTION
    Currently, we provide machines that are already fully setup with the
    client enrolled into all domains and trusts established. This is no
    longer necessary. With this patch, we will enroll into the domains
    using per-topology setup if needed.

    It adds also provisioned_topologies field to mhc.yaml to avoid
    additional provisioning attempt if the topology is already fully setup.

---

Please note that this needs to be closed together with changes to other repositories:
* https://github.com/SSSD/sssd/pull/7349
* https://github.com/SSSD/sssd-ci-containers/pull/95
* https://github.com/next-actions/pytest-mh/pull/54
