### PR TITLE
MISC: Remove a carriage return char at each line end if it exists

### DIFF
--- a/sssd_test_framework/misc/__init__.py
+++ b/sssd_test_framework/misc/__init__.py
@@ -22,7 +22,7 @@ def attrs_parse(lines: list[str], attrs: list[str] | None = None) -> dict[str, l
     out: dict[str, list[str]] = {}
     i = 0
     while i < len(lines):
-        line = lines[i]
+        line = lines[i].rstrip("\r")
         if not line:
             i += 1
             continue

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -72,6 +72,10 @@ def test_attrs_parse__filter():
             ["cn: sudorules", "numbers: one,", "  two,", "  three"],
             {"cn": ["sudorules"], "numbers": ["one, two, three"]},
         ),
+        (
+            ["\r", "\r", "DistinguishedName: CN=user1,CN=Users,DC=ad-n97b,DC=test\r"],
+            {"DistinguishedName": ["CN=user1,CN=Users,DC=ad-n97b,DC=test"]},
+        ),
     ],
 )
 def test_attrs_parse__long_line(input, expected):


### PR DESCRIPTION
Powershell returns \r\n for a new line, and \r can be left after processing the ssh result as below. It causes ValueError in attrs_parse.

lines = ['\r', '\r', 'DistinguishedName : CN=Domain Admins,CN=Users,DC=ad-n97b,DC=test\r',...
line       = '\r'

```
>           (key, value) = map(lambda x: x.lstrip(), line.split(":", 1))
E           ValueError: not enough values to unpack (expected 2, got 1)
```
This removes the carriage return char in attrs_parse before checking attr.