### PR TITLE
roles: add pytest-mh auditd and coredumpd utility to linux roles

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -148,6 +148,7 @@ Additional configuration (host/config section)
 * :ref:`config-artifacts`
 * :ref:`config-providers-client`
 * :ref:`config-auditd`
+* :ref:`config-coredumpd`
 
 .. seealso::
 
@@ -217,6 +218,7 @@ Additional configuration (host/config section)
 * :ref:`config-ldap`
 * :ref:`config-providers-client`
 * :ref:`config-auditd`
+* :ref:`config-coredumpd`
 
 .. seealso::
 
@@ -245,6 +247,7 @@ Additional configuration (host/config section)
   that runs on ``tmpfs`` file system.
 * :ref:`config-artifacts`
 * :ref:`config-auditd`
+* :ref:`config-coredumpd`
 
 .. seealso::
 
@@ -270,6 +273,7 @@ Additional configuration (host/config section)
 * :ref:`config-artifacts`
 * :ref:`config-providers-client`
 * :ref:`config-auditd`
+* :ref:`config-coredumpd`
 
 .. seealso::
 
@@ -374,3 +378,31 @@ provided filter. This expression is evaluated on top of the full output of
         auditd:
           avc_mode: fail|warn|ignore
           avc_filter: <regex>
+
+.. _config-coredumpd:
+
+Coredumpd and automatic core files collection
+=============================================
+
+Linux-based roles has access to Coredumpd utility that automatically collects
+any core files generated during a test. If any core file is produced, it can
+optionally fail the test if required conditions are met.
+
+It is possible to set the core file detection mode to one of ``fail`` (test is
+marked as failed if core file is generated), ``warn`` (result of a test is used
+but the test is marked as ``COREDUMP`` if core file is detected) or ``ignore``
+(auto-detection is turned off, default).
+
+It is also possible to set regular expression that is used to filter the core
+files names in order to fail only if the core file was produced by certain
+process. This expression is evaluated on each name of generated core file.
+
+.. code-block:: yaml
+    :caption: Config example
+
+    - hostname: master.ipa.test
+      role: ipa
+      config:
+        coredumpd:
+          mode: fail|warn|ignore
+          filter: <regex>

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -88,6 +88,7 @@ Additional configuration (host/config section)
 ----------------------------------------------
 
 * :ref:`config-artifacts`
+* :ref:`config-auditd`
 
 .. seealso::
 
@@ -118,6 +119,7 @@ Additional configuration (host/config section)
 * :ref:`config-artifacts`
 * :ref:`config-ldap`
 * :ref:`config-providers-client`
+* :ref:`config-auditd`
 
 .. seealso::
 
@@ -145,6 +147,7 @@ Additional configuration (host/config section)
 
 * :ref:`config-artifacts`
 * :ref:`config-providers-client`
+* :ref:`config-auditd`
 
 .. seealso::
 
@@ -213,6 +216,7 @@ Additional configuration (host/config section)
 * :ref:`config-artifacts`
 * :ref:`config-ldap`
 * :ref:`config-providers-client`
+* :ref:`config-auditd`
 
 .. seealso::
 
@@ -240,6 +244,7 @@ Additional configuration (host/config section)
   containers, this should be ``/dev/shm/exports`` or other writable location
   that runs on ``tmpfs`` file system.
 * :ref:`config-artifacts`
+* :ref:`config-auditd`
 
 .. seealso::
 
@@ -264,6 +269,7 @@ Additional configuration (host/config section)
 * ``realm``: Default Kerberos realm.
 * :ref:`config-artifacts`
 * :ref:`config-providers-client`
+* :ref:`config-auditd`
 
 .. seealso::
 
@@ -339,3 +345,32 @@ the role using :meth:`sssd_test_framework.utils.sssd.HostSSSD.import_domain`.
 The example above will add the given options to ``sssd.conf``, these are
 required by the client to successfully connect to the IPA server. The keytab
 paths are local paths on the client host.
+
+.. _config-auditd:
+
+Auditd and automatic AVC denials detection
+==========================================
+
+Linux-based roles has access to Auditd utility that automatically collects
+audit.log when a test ends. It can also automatically detect AVC denials and
+fail the test if required conditions are met.
+
+It is possible to set that AVC detection mode to one of ``fail`` (test is marked
+as failed if AVC denial is detected), ``warn`` (result of a test is used but the
+test is marked as ``AVC DENIAL`` if denial is detected) or ``ignore``
+(auto-detection is turned off, default).
+
+It is also possible to set a regular expression that is used to filter the AVC
+denials in order to fail only if any of the AVC denial records match the
+provided filter. This expression is evaluated on top of the full output of
+``ausearch`` command.
+
+.. code-block:: yaml
+    :caption: Config example
+
+    - hostname: master.ipa.test
+      role: ipa
+      config:
+        auditd:
+          avc_mode: fail|warn|ignore
+          avc_filter: <regex>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jc
 pytest
 python-ldap
-pytest-mh >= 1.0.14
+pytest-mh >= 1.0.17

--- a/sssd_test_framework/roles/base.py
+++ b/sssd_test_framework/roles/base.py
@@ -8,6 +8,7 @@ from typing import Any, Generic, TypeGuard, TypeVar
 from pytest_mh import MultihostRole
 from pytest_mh.cli import CLIBuilder
 from pytest_mh.utils.auditd import Auditd
+from pytest_mh.utils.coredumpd import Coredumpd
 from pytest_mh.utils.firewall import Firewalld, WindowsFirewall
 from pytest_mh.utils.fs import LinuxFileSystem
 from pytest_mh.utils.journald import JournaldUtils
@@ -165,6 +166,15 @@ class BaseLinuxRole(BaseRole[HostType]):
         self.auditd: Auditd = Auditd(self.host, avc_mode=auditd_avc_mode, avc_filter=auditd_avc_filter)
         """
         Auditd utilities.
+        """
+
+        coredumpd_config = self.host.config.get("coredumpd", {})
+        coredumpd_mode = coredumpd_config.get("mode", "ignore")
+        coredumpd_filter = coredumpd_config.get("filter", None)
+
+        self.coredumpd: Coredumpd = Coredumpd(self.host, self.fs, mode=coredumpd_mode, filter=coredumpd_filter)
+        """
+        Coredumpd utilities.
         """
 
 

--- a/sssd_test_framework/roles/base.py
+++ b/sssd_test_framework/roles/base.py
@@ -7,6 +7,7 @@ from typing import Any, Generic, TypeGuard, TypeVar
 
 from pytest_mh import MultihostRole
 from pytest_mh.cli import CLIBuilder
+from pytest_mh.utils.auditd import Auditd
 from pytest_mh.utils.firewall import Firewalld, WindowsFirewall
 from pytest_mh.utils.fs import LinuxFileSystem
 from pytest_mh.utils.journald import JournaldUtils
@@ -155,6 +156,15 @@ class BaseLinuxRole(BaseRole[HostType]):
         self.sshd: SSHDUtils = SSHDUtils(self.host, self.fs, self.svc)
         """
         Configuring SSH daemon
+        """
+
+        auditd_config = self.host.config.get("auditd", {})
+        auditd_avc_mode = auditd_config.get("avc_mode", "ignore")
+        auditd_avc_filter = auditd_config.get("avc_filter", None)
+
+        self.auditd: Auditd = Auditd(self.host, avc_mode=auditd_avc_mode, avc_filter=auditd_avc_filter)
+        """
+        Auditd utilities.
         """
 
 


### PR DESCRIPTION
This utility can automatically collect audit.log and detect AVC
denials. If AVC denial is detected it can warn or fail the test.

Auditd does not really work on containers, therefore the feature
is disabled by default.

Requires:
* https://github.com/next-actions/pytest-mh/pull/60
* https://github.com/next-actions/pytest-mh/pull/61