### PR TITLE
use generic connection interface from latest pytest-mh

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -17,7 +17,8 @@ Basic definition
       hosts:
       - hostname: <dns host name>
         role: <host role>
-        ssh:
+        conn:
+          type: ssh
           host: <ssh host> (optional, defaults to host name)
           port: <ssh port> (optional, defaults to 22)
           username: <ssh username> (optional, defaults to "root")
@@ -41,11 +42,11 @@ domain has ``id`` attribute and defines the list of available hosts.
   * ``hostname``: DNS host name, it may not necessarily be resolvable from the
     machine that runs pytest
   * ``role``: host role
-  * ``ssh.host``: ssh host to connect to (it may be a resolvable host name or an
+  * ``conn.host``: ssh host to connect to (it may be a resolvable host name or an
     IP address), defaults to the value of ``hostname``
-  * ``ssh.port``: ssh port, defaults to 22
-  * ``ssh.username``: ssh username, defaults to ``root``
-  * ``ssh.password``: ssh password for the user, defaults to ``Secret123``
+  * ``conn.port``: ssh port, defaults to 22
+  * ``conn.username``: ssh username, defaults to ``root``
+  * ``conn.password``: ssh password for the user, defaults to ``Secret123``
   * ``config``: additional configuration, place for custom options, see
     :ref:`custom-config`
   * ``artifacts``: list of artifacts that are automatically downloaded, see

--- a/docs/guides/using-roles.rst
+++ b/docs/guides/using-roles.rst
@@ -461,10 +461,10 @@ needed, you can also run commands on the host directly:
         @pytest.mark.topology(KnownTopology.AD)
         def test_client(client: Client, ad: AD):
             # Commands are executed in bash on Linux systems
-            client.host.ssh.run('echo "test"')
+            client.host.conn.run('echo "test"')
 
             # And in Powershell on Windows
-            ad.host.ssh.run('Write-Output "test"')
+            ad.host.conn.run('Write-Output "test"')
 
 .. seealso::
 

--- a/docs/guides/using-ssh.rst
+++ b/docs/guides/using-ssh.rst
@@ -1,10 +1,9 @@
 Using SSH
 #########
 
-You can use :class:`pytest_mh.ssh.SSHClient` to connect to any host as any
+You can use :class:`pytest_mh.conn.ssh.SSHClient` to connect to any host as any
 user. It is not recommended to instantiate this class on yourself but you should
-rather use :meth:`pytest_mh.MultihostRole.ssh` to get the client
-object.
+rather use :meth:`pytest_mh.MultihostRole.ssh` to get the client object.
 
 Once you establish SSH connections, you can run commands on the remote host in
 both blocking and non-blocking mode.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jc
 pytest
 python-ldap
-pytest-mh >= 1.0.17
+pytest-mh >= 1.0.18

--- a/sssd_test_framework/hosts/ad.py
+++ b/sssd_test_framework/hosts/ad.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import PureWindowsPath
 from typing import Any
 
-from pytest_mh.ssh import SSHLog
+from pytest_mh.conn import ProcessLogLevel
 
 from .base import BaseDomainHost
 
@@ -88,7 +88,7 @@ class ADHost(BaseDomainHost):
         :rtype: str
         """
         if not self.__naming_context:
-            result = self.ssh.run("Write-Host (Get-ADRootDSE).rootDomainNamingContext")
+            result = self.conn.run("Write-Host (Get-ADRootDSE).rootDomainNamingContext")
             nc = result.stdout.strip()
             if not nc:
                 raise ValueError("Unable to find default naming context")
@@ -118,7 +118,7 @@ class ADHost(BaseDomainHost):
         """
         self.logger.info("Creating backup of Active Directory")
 
-        result = self.ssh.run(
+        result = self.conn.run(
             rf"""
             $basedn = '{self.naming_context}'
             $sitesdn = "cn=sites,cn=configuration,$basedn"
@@ -151,7 +151,7 @@ class ADHost(BaseDomainHost):
 
             Write-Output $tmpdir.FullName
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
 
         return PureWindowsPath(result.stdout.strip())
@@ -185,7 +185,7 @@ class ADHost(BaseDomainHost):
         backup_path = str(backup_data)
         self.logger.info(f"Restoring Active Directory from {backup_path}")
 
-        self.ssh.run(
+        self.conn.run(
             rf"""
             $basedn = '{self.naming_context}'
             $sitesdn = "cn=sites,cn=configuration,$basedn"
@@ -253,5 +253,5 @@ class ADHost(BaseDomainHost):
             # If we got here, make sure we exit with 0
             Exit 0
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )

--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from pytest_mh.ssh import SSHLog
+from pytest_mh.conn import ProcessLogLevel
 
 from .base import BaseBackupHost, BaseLinuxHost
 
@@ -39,7 +39,7 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
             return self._features
 
         self.logger.info(f"Detecting SSSD's features on {self.hostname}")
-        result = self.ssh.run(
+        result = self.conn.run(
             """
             set -ex
 
@@ -52,7 +52,7 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
             MANWIDTH=10000 man sssd.conf | grep -q "id_provider = ldap or id_provider = proxy" && \
             echo "limited_enumeration" || :
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
 
         # Set default values
@@ -91,7 +91,7 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
         """
         self.logger.info("Creating backup of SSSD client")
 
-        result = self.ssh.run(
+        result = self.conn.run(
             """
             set -ex
 
@@ -110,7 +110,7 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
 
             echo $path
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
 
         return PurePosixPath(result.stdout_lines[-1].strip())
@@ -131,7 +131,7 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
         backup_path = str(backup_data)
 
         self.logger.info(f"Restoring SSSD data from {backup_path}")
-        self.ssh.run(
+        self.conn.run(
             f"""
             set -ex
 
@@ -149,5 +149,5 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
             restore "{backup_path}/logs" /var/log/sssd
             restore "{backup_path}/lib" /var/lib/sss
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )

--- a/sssd_test_framework/hosts/kdc.py
+++ b/sssd_test_framework/hosts/kdc.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from pytest_mh.ssh import SSHLog
+from pytest_mh.conn import ProcessLogLevel
 
 from .base import BaseDomainHost, BaseLinuxHost
 
@@ -62,14 +62,14 @@ class KDCHost(BaseDomainHost, BaseLinuxHost):
         """
         self.logger.info("Creating backup of KDC")
 
-        result = self.ssh.run(
+        result = self.conn.run(
             """
             set -e
             path=`mktemp`
             kdb5_util dump $path && rm -f "$path.dump_ok"
             echo $path
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
         return PurePosixPath(result.stdout_lines[-1].strip())
 
@@ -89,4 +89,4 @@ class KDCHost(BaseDomainHost, BaseLinuxHost):
         backup_path = str(backup_data)
         self.logger.info(f"Restoring KDC from {backup_path}")
 
-        self.ssh.run(f'kdb5_util load "{backup_path}"', log_level=SSHLog.Error)
+        self.conn.run(f'kdb5_util load "{backup_path}"', log_level=ProcessLogLevel.Error)

--- a/sssd_test_framework/hosts/keycloak.py
+++ b/sssd_test_framework/hosts/keycloak.py
@@ -6,7 +6,7 @@ import time
 from pathlib import PurePosixPath
 from typing import Any
 
-from pytest_mh.ssh import SSHLog, SSHProcessError
+from pytest_mh.conn import ProcessError, ProcessLogLevel
 
 from .base import BaseDomainHost, BaseLinuxHost
 
@@ -53,7 +53,7 @@ class KeycloakHost(BaseDomainHost, BaseLinuxHost):
         for x in range(0, 5):
             try:
                 str_error = None
-                self.ssh.exec(
+                self.conn.exec(
                     [
                         "/opt/keycloak/bin/kcadm.sh",
                         "config",
@@ -68,7 +68,7 @@ class KeycloakHost(BaseDomainHost, BaseLinuxHost):
                         self.adminpw,
                     ]
                 )
-            except SSHProcessError as err:
+            except ProcessError as err:
                 str_error = str(err)
 
             if str_error:
@@ -95,14 +95,14 @@ class KeycloakHost(BaseDomainHost, BaseLinuxHost):
         self.logger.info("Creating backup of Keycloak")
 
         self.stop()
-        cmd = self.ssh.run(
+        cmd = self.conn.run(
             """
             set -e
             path=`mktemp -d`
             /opt/keycloak/bin/kc.sh export --dir "$path"
             echo $path
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
         self.start()
 
@@ -128,11 +128,11 @@ class KeycloakHost(BaseDomainHost, BaseLinuxHost):
         self.logger.info(f"Restoring Keycloak from {backup_path}")
 
         self.stop()
-        self.ssh.run(
+        self.conn.run(
             f"""
             set -e
             /opt/keycloak/bin/kc.sh import --dir '{backup_path}'
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
         self.start()

--- a/sssd_test_framework/hosts/nfs.py
+++ b/sssd_test_framework/hosts/nfs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from pytest_mh.ssh import SSHLog
+from pytest_mh.conn import ProcessLogLevel
 
 from .base import BaseBackupHost, BaseLinuxHost
 
@@ -58,14 +58,14 @@ class NFSHost(BaseBackupHost, BaseLinuxHost):
         """
         self.logger.info("Creating backup of NFS server")
 
-        result = self.ssh.run(
+        result = self.conn.run(
             rf"""
             set -e
             path=`mktemp`
             tar --ignore-failed-read -czvf "$path" "{self.exports_dir}" /etc/exports /etc/exports.d
             echo $path
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )
 
         return PurePosixPath(result.stdout_lines[-1].strip())
@@ -86,7 +86,7 @@ class NFSHost(BaseBackupHost, BaseLinuxHost):
         backup_path = str(backup_data)
         self.logger.info(f"Restoring NFS server from {backup_path}")
 
-        self.ssh.run(
+        self.conn.run(
             rf"""
             set -e
             rm -fr "{self.exports_dir}/*"
@@ -94,5 +94,5 @@ class NFSHost(BaseBackupHost, BaseLinuxHost):
             tar -xf "{backup_path}" -C /
             exportfs -r
             """,
-            log_level=SSHLog.Error,
+            log_level=ProcessLogLevel.Error,
         )

--- a/sssd_test_framework/roles/base.py
+++ b/sssd_test_framework/roles/base.py
@@ -7,6 +7,8 @@ from typing import Any, Generic, TypeGuard, TypeVar
 
 from pytest_mh import MultihostRole
 from pytest_mh.cli import CLIBuilder
+from pytest_mh.conn import Bash, Powershell, Shell
+from pytest_mh.conn.ssh import SSHClient
 from pytest_mh.utils.auditd import Auditd
 from pytest_mh.utils.coredumpd import Coredumpd
 from pytest_mh.utils.firewall import Firewalld, WindowsFirewall
@@ -104,6 +106,30 @@ class BaseRole(MultihostRole[HostType]):
         Features supported by the role.
         """
         return self.host.features
+
+    def ssh(self, user: str, password: str, *, shell: Shell | None = None) -> SSHClient:
+        """
+        Open SSH connection to the host as given user.
+
+        :param user: Username.
+        :type user: str
+        :param password: User password.
+        :type password: str
+        :param shell: Shell that will run the commands, defaults to ``None`` (= ``Bash``)
+        :type shell: Shell | None, optional
+        :return: SSH client connection.
+        :rtype: SSHClient
+        """
+        if shell is None:
+            shell = Bash()
+
+        return SSHClient(
+            self.host.hostname,
+            user=user,
+            password=password,
+            shell=shell,
+            logger=self.logger,
+        )
 
 
 class BaseLinuxRole(BaseRole[HostType]):
@@ -209,3 +235,21 @@ class BaseWindowsRole(BaseRole[HostType]):
         """
         Configure Windows firewall.
         """
+
+    def ssh(self, user: str, password: str, *, shell: Shell | None = None) -> SSHClient:
+        """
+        Open SSH connection to the host as given user.
+
+        :param user: Username.
+        :type user: str
+        :param password: User password.
+        :type password: str
+        :param shell: Shell that will run the commands, defaults to ``None`` (= ``Powershell``)
+        :type shell: Shell | None, optional
+        :return: SSH client connection.
+        :rtype: SSHClient
+        """
+        if shell is None:
+            shell = Powershell()
+
+        return super().ssh(user, password, shell=shell)

--- a/sssd_test_framework/roles/client.py
+++ b/sssd_test_framework/roles/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 
 from ..hosts.client import ClientHost
 from ..topology import SSSDTopologyMark
@@ -105,13 +105,13 @@ class Client(BaseLinuxRole[ClientHost]):
 
                 self.sssd.import_domain(domain, role)
 
-    def sss_ssh_knownhosts(self, *args: str) -> SSHProcessResult:
+    def sss_ssh_knownhosts(self, *args: str) -> ProcessResult:
         """
         Execute sss_ssh_knownhosts.
 
         :param `*args`: Command arguments.
         :type `*args`: str
         :return: Command result.
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
-        return self.host.ssh.exec(["sss_ssh_knownhosts", *args])
+        return self.host.conn.exec(["sss_ssh_knownhosts", *args])

--- a/sssd_test_framework/roles/kdc.py
+++ b/sssd_test_framework/roles/kdc.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 
 from ..hosts.kdc import KDCHost
 from .base import BaseLinuxRole, BaseObject
@@ -58,14 +58,14 @@ class KDC(BaseLinuxRole[KDCHost]):
 
         return f"{name}@{self.realm}"
 
-    def kadmin(self, command: str) -> SSHProcessResult:
+    def kadmin(self, command: str) -> ProcessResult:
         """
         Run kadmin command on the KDC.
 
         :param command: kadmin command
         :type command: str
         """
-        result = self.host.ssh.exec(["kadmin.local", "-q", command])
+        result = self.host.conn.exec(["kadmin.local", "-q", command])
 
         # Remove "Authenticating as principal root/admin@TEST with password."
         # from the output and keep only output of the command itself.

--- a/sssd_test_framework/roles/keycloak.py
+++ b/sssd_test_framework/roles/keycloak.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import shlex
 
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 
 from ..hosts.keycloak import KeycloakHost
 from .base import BaseLinuxRole, BaseObject
@@ -30,7 +30,7 @@ class Keycloak(BaseLinuxRole[KeycloakHost]):
         super().setup()
         self.host.kclogin()
 
-    def kcadm(self, command: str) -> SSHProcessResult:
+    def kcadm(self, command: str) -> ProcessResult:
         """
         Run kcadm command on the Keycloak server.
 
@@ -42,7 +42,7 @@ class Keycloak(BaseLinuxRole[KeycloakHost]):
         """
         kcadm = "/opt/keycloak/bin/kcadm.sh"
         command_split = shlex.split(command)
-        result = self.host.ssh.exec([kcadm] + command_split)
+        result = self.host.conn.exec([kcadm] + command_split)
         return result
 
     def user(self, name: str) -> KeycloakUser:

--- a/sssd_test_framework/roles/nfs.py
+++ b/sssd_test_framework/roles/nfs.py
@@ -44,7 +44,7 @@ class NFS(BaseLinuxRole[NFSHost]):
         """
         Reexport all directories.
         """
-        self.host.ssh.run("exportfs -r && exportfs -s")
+        self.host.conn.run("exportfs -r && exportfs -s")
 
     def export(
         self,

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -6,7 +6,7 @@ from typing import Any, TypeAlias
 
 import ldap.modlist
 from pytest_mh.cli import CLIBuilderArgs
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 
 from sssd_test_framework.utils.ldap import LDAPRecordAttributes
 
@@ -313,7 +313,7 @@ class SambaObject(BaseObject):
 
         self.__dn: str | None = None
 
-    def _exec(self, op: str, args: list[str] | None = None, **kwargs) -> SSHProcessResult:
+    def _exec(self, op: str, args: list[str] | None = None, **kwargs) -> ProcessResult:
         """
         Execute samba-tool command.
 
@@ -327,12 +327,12 @@ class SambaObject(BaseObject):
         :param args: List of additional command arguments, defaults to None
         :type args: list[str] | None, optional
         :return: SSH process result.
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
         if args is None:
             args = []
 
-        return self.role.host.ssh.exec(["samba-tool", self.command, op, self.name, *args], **kwargs)
+        return self.role.host.conn.exec(["samba-tool", self.command, op, self.name, *args], **kwargs)
 
     def _add(self, attrs: CLIBuilderArgs) -> None:
         """
@@ -380,7 +380,7 @@ class SambaObject(BaseObject):
         # Build diff
         modlist = ldap.modlist.modifyModlist(old_attrs, new_attrs)
         if modlist:
-            self.role.host.conn.modify_s(dn, modlist)
+            self.role.host.ldap_conn.modify_s(dn, modlist)
 
     def delete(self) -> None:
         """

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -4,7 +4,7 @@ from functools import partial, wraps
 from typing import Any
 
 from pytest_mh import TopologyController
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 
 from .config import SSSDMultihostConfig
 from .hosts.ad import ADHost
@@ -157,7 +157,7 @@ class IPATopologyController(BackupTopologyController):
         client.fs.backup("/var/lib/ipa-client")
 
         # Join ipa domain
-        client.ssh.exec(["realm", "join", ipa.domain], input=ipa.adminpw)
+        client.conn.exec(["realm", "join", ipa.domain], input=ipa.adminpw)
 
         # Backup so we can restore to this state after each test
         self.backup_data[ipa] = ipa.backup()
@@ -183,7 +183,7 @@ class ADTopologyController(BackupTopologyController):
         client.fs.rm("/etc/krb5.keytab")
 
         # Join AD domain
-        client.ssh.exec(["realm", "join", provider.domain], input=provider.adminpw)
+        client.conn.exec(["realm", "join", provider.domain], input=provider.adminpw)
 
         # Backup so we can restore to this state after each test
         self.backup_data[provider] = provider.backup()
@@ -228,7 +228,7 @@ class IPATrustADTopologyController(BackupTopologyController):
             client.fs.backup("/var/lib/ipa-client")
 
             # Join IPA domain)
-            client.ssh.exec(["realm", "join", ipa.domain], input=ipa.adminpw)
+            client.conn.exec(["realm", "join", ipa.domain], input=ipa.adminpw)
 
         # Backup so we can restore to this state after each test
         self.backup_data[ipa] = ipa.backup()
@@ -238,8 +238,8 @@ class IPATrustADTopologyController(BackupTopologyController):
     # If this command is run on freshly started containers, it is possible the IPA is not yet
     # fully ready to create the trust. It takes a while for it to start working.
     @retry_command(max_retries=20, delay=5, match_stderr='CIFS server communication error: code "3221225581"')
-    def trust_add(self, ipa: IPAHost, trusted: ADHost | SambaHost) -> SSHProcessResult:
-        return ipa.ssh.exec(
+    def trust_add(self, ipa: IPAHost, trusted: ADHost | SambaHost) -> ProcessResult:
+        return ipa.conn.exec(
             ["ipa", "trust-add", trusted.domain, "--admin", "Administrator", "--password"], input=trusted.adminpw
         )
 

--- a/sssd_test_framework/utils/authselect.py
+++ b/sssd_test_framework/utils/authselect.py
@@ -40,8 +40,8 @@ class AuthselectUtils(MultihostUtility[MultihostHost]):
         :meta private:
         """
         if self.__backup is not None:
-            self.host.ssh.exec(["authselect", "backup-restore", self.__backup])
-            self.host.ssh.exec(["rm", "-fr", f"/var/lib/authselect/backups/{self.__backup}"])
+            self.host.conn.exec(["authselect", "backup-restore", self.__backup])
+            self.host.conn.exec(["rm", "-fr", f"/var/lib/authselect/backups/{self.__backup}"])
             self.__backup = None
 
         super().teardown()
@@ -60,7 +60,7 @@ class AuthselectUtils(MultihostUtility[MultihostHost]):
             self.__backup = "multihost.backup"
             backup = [f"--backup={self.__backup}"]
 
-        self.host.ssh.exec(["authselect", "select", profile, *features, "--force", *backup])
+        self.host.conn.exec(["authselect", "select", profile, *features, "--force", *backup])
 
     def current(self) -> str:
         """
@@ -68,7 +68,7 @@ class AuthselectUtils(MultihostUtility[MultihostHost]):
         :return: Authselect configuration
         :rtype: str
         """
-        result = self.host.ssh.exec(["authselect", "current"]).stdout
+        result = self.host.conn.exec(["authselect", "current"]).stdout
 
         return result
 
@@ -82,7 +82,7 @@ class AuthselectUtils(MultihostUtility[MultihostHost]):
         if self.__backup is None:
             self.__backup = "multihost.backup"
             backup = [f"--backup={self.__backup}"]
-        self.host.ssh.exec(["authselect", "disable-feature", *features, *backup])
+        self.host.conn.exec(["authselect", "disable-feature", *features, *backup])
 
     def enable_feature(self, features: list[str]) -> None:
         """
@@ -95,4 +95,4 @@ class AuthselectUtils(MultihostUtility[MultihostHost]):
             self.__backup = "multihost.backup"
             backup = [f"--backup={self.__backup}"]
 
-        self.host.ssh.exec(["authselect", "enable-feature", *features, *backup])
+        self.host.conn.exec(["authselect", "enable-feature", *features, *backup])

--- a/sssd_test_framework/utils/automount.py
+++ b/sssd_test_framework/utils/automount.py
@@ -101,7 +101,7 @@ class AutomountUtils(MultihostUtility[MultihostHost]):
         :rtype: bool
         """
 
-        result = self.host.ssh.run(
+        result = self.host.conn.run(
             rf"""
         set -ex
         pushd "{path}"
@@ -152,7 +152,7 @@ class AutomountUtils(MultihostUtility[MultihostHost]):
         :return: Parsed ``automount -m`` output.
         :rtype: dict[str, dict[str, list[str]]]
         """
-        result = self.host.ssh.run("automount -m")
+        result = self.host.conn.run("automount -m")
 
         def parse_result(lines: list[str]) -> dict[str, dict[str, str | list[str]]]:
             mountpoints: dict[str, dict[str, str | list[str]]] = {}

--- a/sssd_test_framework/utils/ldap.py
+++ b/sssd_test_framework/utils/ldap.py
@@ -35,7 +35,7 @@ class LDAPUtils(MultihostUtility[BaseLDAPDomainHost]):
 
         :rtype: ldap.ldapobject.LDAPObject
         """
-        return self.host.conn
+        return self.host.ldap_conn
 
     @property
     def naming_context(self) -> str:

--- a/sssd_test_framework/utils/ldb.py
+++ b/sssd_test_framework/utils/ldb.py
@@ -58,5 +58,5 @@ class LDBUtils(MultihostUtility[MultihostHost]):
         if filter is not None:
             additional.append(filter)
 
-        result = self.host.ssh.exec(["ldbsearch", *args, "-H", path, *additional])
+        result = self.host.conn.exec(["ldbsearch", *args, "-H", path, *additional])
         return parse_ldif(result.stdout)

--- a/sssd_test_framework/utils/pam.py
+++ b/sssd_test_framework/utils/pam.py
@@ -81,7 +81,7 @@ class PAMAccessUtils(MultihostUtility):
         :rtype: str
         """
         self.logger.info(f"Reading {self.file} and parsing as Augeas tree")
-        result = self.host.ssh.run(f"augtool {self.args} print {self.path}")
+        result = self.host.conn.run(f"augtool {self.args} print {self.path}")
 
         return result.stdout
 
@@ -96,9 +96,9 @@ class PAMAccessUtils(MultihostUtility):
             raise ValueError("No data!")
 
         index = 1
-        for i in self.host.ssh.run(f"augtool {self.args} match {self.path}/*").stdout_lines:
+        for i in self.host.conn.run(f"augtool {self.args} match {self.path}/*").stdout_lines:
             node = re.sub("\\d", str(index), i.split("=")[0].strip())
-            leaf = self.host.ssh.run(f"augtool {self.args} match {node}/*").stdout_lines
+            leaf = self.host.conn.run(f"augtool {self.args} match {node}/*").stdout_lines
             access = i.split("=")[1].strip()
             user = leaf[0].split("=")[1].strip()
             origin = leaf[1].split("=")[1].strip()
@@ -106,7 +106,7 @@ class PAMAccessUtils(MultihostUtility):
             for y in value:
                 if match == y:
                     self.logger.info(f"Deleting node in Augeas tree {self.file}")
-                    self.host.ssh.run(f"augtool {self.args} --autosave rm {node}")
+                    self.host.conn.run(f"augtool {self.args} --autosave rm {node}")
                 else:
                     index = +index
 
@@ -127,7 +127,7 @@ class PAMAccessUtils(MultihostUtility):
             self.cmd = self.cmd + f"set {self.path}/access[{count}]/origin " + i["origin"] + "\n"
             count = +count
 
-        self.host.ssh.run(f"augtool --echo {self.args}", input=f"{self.cmd} save\n")
+        self.host.conn.run(f"augtool --echo {self.args}", input=f"{self.cmd} save\n")
 
 
 class PAMFaillockUtils(MultihostUtility):
@@ -192,7 +192,7 @@ class PAMFaillockUtils(MultihostUtility):
         :rtype: str
         """
         self.logger.info(f"Reading {self.file} and parsing as Augeas tree")
-        result = self.host.ssh.run(f"augtool {self.args} print {self.path}").stdout
+        result = self.host.conn.run(f"augtool {self.args} print {self.path}").stdout
 
         return result
 
@@ -208,7 +208,7 @@ class PAMFaillockUtils(MultihostUtility):
 
         self.logger.info(f"Deleting node in Augeas tree in {self.file}")
         for k, v in value.items():
-            self.host.ssh.run(f"augtool {self.args} --autosave rm {self.path}/{k} {v}")
+            self.host.conn.run(f"augtool {self.args} --autosave rm {self.path}/{k} {v}")
 
     def config_set(self, value: dict[str, str]) -> None:
         """
@@ -223,4 +223,4 @@ class PAMFaillockUtils(MultihostUtility):
         for k, v in value.items():
             self.cmd = self.cmd + f"set {self.path}/{k} {v}\n"
 
-        self.host.ssh.run(f"augtool --echo {self.args}", input=f"{self.cmd}save\n")
+        self.host.conn.run(f"augtool --echo {self.args}", input=f"{self.cmd}save\n")

--- a/sssd_test_framework/utils/sbus.py
+++ b/sssd_test_framework/utils/sbus.py
@@ -7,7 +7,7 @@ from abc import ABC
 from typing import Any, Final
 
 from pytest_mh import MultihostHost, MultihostUtility
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 
 from .dbus.types import DBUSResult, DBUSSignatureReader, DBUSType, DBUSTypeString, DBUSTypeVariant
 
@@ -76,13 +76,13 @@ class ProxyObject(ABC):
         for arg in args:
             cmd += " " + arg.param()
 
-        result = self.host.ssh.run(cmd)
+        result = self.host.conn.run(cmd)
         if result.stdout_lines[0].startswith("method return"):
             lines = result.stdout_lines[1:]
         else:
             lines = result.stdout_lines
 
-        return SSHProcessResult(result.rc, lines, result.stderr_lines)
+        return ProcessResult(result.rc, lines, result.stderr_lines, result.error)
 
 
 class ProxyProperty(ProxyObject):

--- a/sssd_test_framework/utils/sshd.py
+++ b/sssd_test_framework/utils/sshd.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pytest_mh import MultihostHost, MultihostUtility, mh_utility_postpone_setup
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 from pytest_mh.utils.fs import LinuxFileSystem
 from pytest_mh.utils.services import SystemdServices
 
@@ -78,7 +78,7 @@ class SSHDUtils(MultihostUtility[MultihostHost]):
         :rtype: str
         """
         self.logger.info(f"Reading {self.file} and parsing as Augeas tree")
-        result = self.host.ssh.run(f"augtool {self.args} print {self.path}")
+        result = self.host.conn.run(f"augtool {self.args} print {self.path}")
 
         return result.stdout
 
@@ -96,7 +96,7 @@ class SSHDUtils(MultihostUtility[MultihostHost]):
         self.logger.info(f"Deleting node in Augeas tree in {self.file}")
         for i in value:
             for k, v in i.items():
-                self.host.ssh.run(f"augtool {self.args} --autosave rm {self.path}/{k} {v}")
+                self.host.conn.run(f"augtool {self.args} --autosave rm {self.path}/{k} {v}")
 
     def config_set(self, value: list[dict[str, str]]) -> None:
         """
@@ -113,14 +113,14 @@ class SSHDUtils(MultihostUtility[MultihostHost]):
             for k, v in i.items():
                 self.cmd = self.cmd + f"set {self.path}/{k} {v}\n"
 
-        self.host.ssh.run(f"augtool --echo {self.args}", input=f"{self.cmd}save\n")
+        self.host.conn.run(f"augtool --echo {self.args}", input=f"{self.cmd}save\n")
 
     def reload(
         self,
         service="sshd",
         *,
         raise_on_error: bool = True,
-    ) -> SSHProcessResult:
+    ) -> ProcessResult:
         """
         Reload the SSH daemon.
 
@@ -129,6 +129,6 @@ class SSHDUtils(MultihostUtility[MultihostHost]):
         :param raise_on_error: Raise exception on error, defaults to True
         :type raise_on_error: bool, optional
         :return: SSH process result.
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
         return self.svc.reload(service, raise_on_error=raise_on_error)

--- a/sssd_test_framework/utils/sss_override.py
+++ b/sssd_test_framework/utils/sss_override.py
@@ -25,7 +25,7 @@ class SSSOverrideUtils(MultihostUtility[MultihostHost]):
         """
         super().__init__(host)
 
-        self.cli: CLIBuilder = CLIBuilder(host.ssh)
+        self.cli: CLIBuilder = CLIBuilder(host.conn)
         self.fs: LinuxFileSystem = fs
 
     def user(self, name: str) -> SSSOverrideUser:
@@ -120,12 +120,12 @@ class SSSOverrideUtils(MultihostUtility[MultihostHost]):
         if users:
             self.logger.info(f"Exporting user local overrides data to {users} on {self.host.hostname}")
             self.fs.backup(users)
-            self.host.ssh.exec(["sss_override", "user-export", users])
+            self.host.conn.exec(["sss_override", "user-export", users])
 
         if groups:
             self.logger.info(f"Exporting group local overrides data to {groups} on {self.host.hostname}")
             self.fs.backup(groups)
-            self.host.ssh.exec(["sss_override", "group-export", groups])
+            self.host.conn.exec(["sss_override", "group-export", groups])
 
     def import_data(
         self,
@@ -148,12 +148,12 @@ class SSSOverrideUtils(MultihostUtility[MultihostHost]):
         if users:
             self.logger.info(f"Importing user local overrides data from {users} on {self.host.hostname}")
             self.fs.backup(users)
-            self.host.ssh.exec(["sss_override", "user-import", users])
+            self.host.conn.exec(["sss_override", "user-import", users])
 
         if groups:
             self.logger.info(f"Importing group local overrides data from {groups} on {self.host.hostname}")
             self.fs.backup(groups)
-            self.host.ssh.exec(["sss_override", "group-import", groups])
+            self.host.conn.exec(["sss_override", "group-import", groups])
 
 
 class SSSOverrideUser:
@@ -213,7 +213,7 @@ class SSSOverrideUser:
         }
 
         self.util.logger.info(f"Creating local override for user {self.user} on {self.util.host.hostname}")
-        self.util.host.ssh.exec(["sss_override", "user-add", self.user] + self.util.cli.args(args))
+        self.util.host.conn.exec(["sss_override", "user-add", self.user] + self.util.cli.args(args))
 
         return self
 
@@ -222,7 +222,7 @@ class SSSOverrideUser:
         Delete the local override for user.
         """
         self.util.logger.info(f"Deleting local override for user {self.user} on {self.util.host.hostname}")
-        self.util.host.ssh.exec(["sss_override", "user-del", self.user])
+        self.util.host.conn.exec(["sss_override", "user-del", self.user])
 
         return self
 
@@ -237,7 +237,7 @@ class SSSOverrideUser:
         """
 
         self.util.logger.info(f"Fetching local override data for user {self.user} on {self.util.host.hostname}")
-        output = self.util.host.ssh.exec(["sss_override", "user-show", self.user])
+        output = self.util.host.conn.exec(["sss_override", "user-show", self.user])
         if not output.stdout:
             return None
 
@@ -298,7 +298,7 @@ class SSSOverrideGroup:
         }
 
         self.util.logger.info(f"Creating local override for group {self.group} on {self.util.host.hostname}")
-        self.util.host.ssh.exec(["sss_override", "group-add", self.group] + self.util.cli.args(args))
+        self.util.host.conn.exec(["sss_override", "group-add", self.group] + self.util.cli.args(args))
 
         return self
 
@@ -307,7 +307,7 @@ class SSSOverrideGroup:
         Delete the local override for group.
         """
         self.util.logger.info(f"Deleting local override for group {self.group} on {self.util.host.hostname}")
-        self.util.host.ssh.exec(["sss_override", "group-del", self.group])
+        self.util.host.conn.exec(["sss_override", "group-del", self.group])
 
         return self
 
@@ -321,7 +321,7 @@ class SSSOverrideGroup:
         :rtype: dict[str, list[str]]
         """
         self.util.logger.info(f"Fetching local override group {self.group} on {self.util.host.hostname}")
-        output = self.util.host.ssh.exec(["sss_override", "group-show", self.group])
+        output = self.util.host.conn.exec(["sss_override", "group-show", self.group])
         if not output.stdout:
             return None
 

--- a/sssd_test_framework/utils/sssctl.py
+++ b/sssd_test_framework/utils/sssctl.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pytest_mh import MultihostHost, MultihostUtility
 from pytest_mh.cli import CLIBuilder, CLIBuilderArgs
-from pytest_mh.ssh import SSHProcessResult
+from pytest_mh.conn import ProcessResult
 from pytest_mh.utils.fs import LinuxFileSystem
 
 __all__ = [
@@ -101,7 +101,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
             "domain": (self.cli.option.VALUE, domain),
         }
 
-        self.host.ssh.exec(["sssctl", "cache-expire"] + self.cli.args(args))
+        self.host.conn.exec(["sssctl", "cache-expire"] + self.cli.args(args))
 
     def passkey_register(
         self,
@@ -149,7 +149,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         )
 
         if pin is not None:
-            result = self.host.ssh.expect(
+            result = self.host.conn.expect(
                 f"""
                 spawn {command}
                 expect {{
@@ -163,7 +163,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
                 raise_on_error=True,
             )
         else:
-            result = self.host.ssh.expect(
+            result = self.host.conn.expect(
                 f"""
                 spawn {command}
                 expect eof
@@ -173,7 +173,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
 
         return result.stdout_lines[-1].strip()
 
-    def user_checks(self, username: str, action: str = "acct", service: str = "system-auth") -> SSHProcessResult:
+    def user_checks(self, username: str, action: str = "acct", service: str = "system-auth") -> ProcessResult:
         """
         Print information about a user and check authentication
 
@@ -184,11 +184,11 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         :param service: PAM service, defaults to "system-auth"
         :type service: str
         :return: Result of called command
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
-        return self.host.ssh.exec(["sssctl", "user-checks", username, "-a", action, "-s", service])
+        return self.host.conn.exec(["sssctl", "user-checks", username, "-a", action, "-s", service])
 
-    def user_show(self, user: str | None = None, sid: str | None = None, uid: int | None = None) -> SSHProcessResult:
+    def user_show(self, user: str | None = None, sid: str | None = None, uid: int | None = None) -> ProcessResult:
         """
         Information about cached user
 
@@ -199,7 +199,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         :param uid: Search by user ID, defaults to None
         :type uid: int | None
         :return: Result of called command
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
         options = []
         if user is not None:
@@ -209,9 +209,9 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         if uid is not None:
             options += ["-u", str(uid)]
 
-        return self.host.ssh.exec(["sssctl", "user-show", *options])
+        return self.host.conn.exec(["sssctl", "user-show", *options])
 
-    def config_check(self, config: str | None = None, snippet: str | None = None) -> SSHProcessResult:
+    def config_check(self, config: str | None = None, snippet: str | None = None) -> ProcessResult:
         """
         Call ``sssctl config-check`` with additional arguments
 
@@ -220,14 +220,14 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         :param snippet: Non default snippet dir, defaults to None
         :type snippet: str
         :return: Result of called command
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
         args: CLIBuilderArgs = {
             "config": (self.cli.option.VALUE, config),
             "snippet": (self.cli.option.VALUE, snippet),
         }
 
-        return self.host.ssh.exec(["sssctl", "config-check"] + self.cli.args(args), raise_on_error=False)
+        return self.host.conn.exec(["sssctl", "config-check"] + self.cli.args(args), raise_on_error=False)
 
     def domain_status(
         self,
@@ -237,7 +237,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         active: bool = False,
         servers: bool = False,
         start: bool = False,
-    ) -> SSHProcessResult:
+    ) -> ProcessResult:
         """
         Call ``sssctl domain-status @domain`` with additional arguments.
 
@@ -252,7 +252,7 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         :param start: Start SSSD if it is not running, defaults to False
         :type start: bool, optional
         :return: Result of called command.
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
         args: CLIBuilderArgs = {
             "online": (self.cli.option.SWITCH, online),
@@ -262,9 +262,9 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
             "domain": (self.cli.option.POSITIONAL, domain),
         }
 
-        return self.host.ssh.exec(["sssctl", "domain-status"] + self.cli.args(args), raise_on_error=False)
+        return self.host.conn.exec(["sssctl", "domain-status"] + self.cli.args(args), raise_on_error=False)
 
-    def analyze_request(self, command: str, source: str | None = None, logdir: str | None = None) -> SSHProcessResult:
+    def analyze_request(self, command: str, source: str | None = None, logdir: str | None = None) -> ProcessResult:
         """
         Call ``sssctl analyze [arguments] request command``
 
@@ -275,13 +275,13 @@ class SSSCTLUtils(MultihostUtility[MultihostHost]):
         :param logdir: SSSD Log directory to parse log files from, defaults to None
         :type logdir: str | None, optional
         :return: Result of called command
-        :rtype: SSHProcessResult
+        :rtype: ProcessResult
         """
         args: CLIBuilderArgs = {
             "source": (self.cli.option.VALUE, source),
             "logdir": (self.cli.option.VALUE, logdir),
         }
 
-        return self.host.ssh.exec(
+        return self.host.conn.exec(
             ["sssctl", "analyze"] + self.cli.args(args) + ["request"] + command.split(), raise_on_error=False
         )


### PR DESCRIPTION
Latest version added an option to replace SSH connections with podman
or docker, therefore a generic interface was created. Most notably,
`host.ssh` was replaced with `host.conn`.

Depends on:
* https://github.com/next-actions/pytest-mh/pull/67