### PR TITLE
docs: refactoring guide titles and files

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -1,21 +1,21 @@
-How to guides
+How-To Guides
 #############
 
 .. toctree::
 
-   check-sssd-functionality
-   using-roles
-   using-ssh
+   skipping-conditional-tests
    testing-authentication
    testing-autofs
    testing-dbus
    testing-gpo
    testing-identity
+   testing-ipa-trust
    testing-ldap-krb5
+   testing-local-overrides
+   testing-local-users
    testing-netgroups
-   testing-sss_override
    testing-offline
    testing-passkey
    testing-pam
-   testing-ipa-trust
-   testing-local-users
+   using-roles
+   using-ssh

--- a/docs/guides/skipping-conditional-tests.rst
+++ b/docs/guides/skipping-conditional-tests.rst
@@ -1,5 +1,5 @@
-Skipping tests if SSSD is missing feature
-#########################################
+Skipping Conditional Tests
+##########################
 
 On some situations, SSSD code base is providing specific functionality by
 enabling it via a configure time flag. A typical example is a files provider

--- a/docs/guides/testing-authentication.rst
+++ b/docs/guides/testing-authentication.rst
@@ -1,4 +1,4 @@
-Testing authentication and sudo
+Testing Authentication and Sudo
 ###############################
 
 Class :class:`sssd_test_framework.utils.authentication.AuthenticationUtils`

--- a/docs/guides/testing-autofs.rst
+++ b/docs/guides/testing-autofs.rst
@@ -1,5 +1,5 @@
-Testing autofs / automount
-##########################
+Testing AutoFS and Automount
+############################
 
 Class :class:`sssd_test_framework.utils.automount.AutomountUtils` provides API
 that can be used to test autofs / automount functionality. It can test that the

--- a/docs/guides/testing-dbus.rst
+++ b/docs/guides/testing-dbus.rst
@@ -1,7 +1,9 @@
 Testing D-Bus Services
 ======================
+
 Infopipe
---------
+********
+
 Access to the Infopipe services is achieved through the
 :class:`sssd_test_framework.roles.client.Client` class. It provides the
 :meth:`sssd_test_framework.roles.client.Client.infopipe()` method that

--- a/docs/guides/testing-gpo.rst
+++ b/docs/guides/testing-gpo.rst
@@ -1,7 +1,7 @@
-Testing AD GPO HBAC
-###################
+Testing GPOs
+############
 
-:class:`~sssd_test_framework.roles.ad.AD.GPO`
+Class :class:`sssd_test_framework.roles.ad.GPO`
 provides Group Policy Objects (GPO) management to configure GPO policies on AD. Allowing us
 to manage Host Based Access Control(HBAC) from the domain controller. GPOs are windows policies,
 consisting of computer and user configurations, registry keys, administrative template, security

--- a/docs/guides/testing-identity.rst
+++ b/docs/guides/testing-identity.rst
@@ -1,4 +1,4 @@
-Testing identity
+Testing Identity
 ################
 
 Class :class:`sssd_test_framework.utils.tools.LinuxToolsUtils` provides access

--- a/docs/guides/testing-ipa-trust.rst
+++ b/docs/guides/testing-ipa-trust.rst
@@ -1,5 +1,5 @@
-Testing IPA trust with AD and Samba
-###################################
+Testing IPA Trusts
+##################
 
 To test setup with IPA server and trusted Active Directory or Samba domain,
 you can use the following topologies:

--- a/docs/guides/testing-ldap-krb5.rst
+++ b/docs/guides/testing-ldap-krb5.rst
@@ -1,4 +1,4 @@
-Testing LDAP with Kerberos
+Testing LDAP With Kerberos
 ##########################
 
 SSSD's LDAP provider can be configured to use Kerberos as the authentication

--- a/docs/guides/testing-local-overrides.rst
+++ b/docs/guides/testing-local-overrides.rst
@@ -1,5 +1,5 @@
-Local override of users and groups
-###################################
+Testing Local Overrides
+#######################
 
 Class :class:`sssd_test_framework.utils.sss_override.SSSOverrideUtils` provides
 an API to manage local overrides for users and groups. Also known as ID views,

--- a/docs/guides/testing-local-users.rst
+++ b/docs/guides/testing-local-users.rst
@@ -1,5 +1,5 @@
-Local users and groups
-######################
+Testing Local Users and Groups
+##############################
 
 Class :class:`sssd_test_framework.utils.local_users.LocalUsersUtils` provides
 API to manage local users and groups. It shares the same generic API that is

--- a/docs/guides/testing-netgroups.rst
+++ b/docs/guides/testing-netgroups.rst
@@ -1,4 +1,4 @@
-Testing netgroups
+Testing Netgroups
 #################
 
 Class :class:`sssd_test_framework.utils.tools.LinuxToolsUtils` provides access
@@ -122,7 +122,6 @@ For most simple cases, you can avoid comparing the domain part like this:
 
 .. code-block:: python
     :caption: Example with topology parametrization
-    :emphasize-lines: 15-16
 
     @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
     def test_netgroup(client: Client, provider: GenericProvider):

--- a/docs/guides/testing-offline.rst
+++ b/docs/guides/testing-offline.rst
@@ -1,4 +1,4 @@
-Testing SSSD in offline mode
+Testing When SSSD is Offline
 ############################
 
 In order to test SSSD in offline mode, we can use the firewall module from

--- a/docs/guides/testing-pam.rst
+++ b/docs/guides/testing-pam.rst
@@ -1,5 +1,5 @@
-Pluggable Authentication Modules / PAM
-######################################
+Testing PAM Modules
+###################
 
 Class :class:`sssd_test_framework.utils.pam.PAMUtils` provides
 an API to manage PAM module configuration. Currently pam_access and pam_faillock is supported.
@@ -10,8 +10,9 @@ A module for logdaemon style login access control. This is managed by /etc/secur
 
 .. code-block:: python
     :caption: Example PAM Access usage
-     @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-     def test_example(client: Client, provider: GenericProvider):
+
+    @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+    def test_example(client: Client, provider: GenericProvider):
         # Add users
         provider.user("user-1").add()
         provider.user("user-2").add()

--- a/docs/guides/testing-passkey.rst
+++ b/docs/guides/testing-passkey.rst
@@ -1,5 +1,5 @@
-Testing passkey authentication
-##############################
+Testing Passkeys
+################
 
 Passkey can be tested using passkey related methods from
 :class:`sssd_test_framework.utils.sssctl.SSSCTLUtils` and

--- a/docs/guides/using-roles.rst
+++ b/docs/guides/using-roles.rst
@@ -1,5 +1,5 @@
-Using multihost roles
-#####################
+Using Roles
+###########
 
 Multihost role is the main object that gives you access to the remote host. Role
 represents a service that runs on the host and the role object provides

--- a/docs/guides/using-ssh.rst
+++ b/docs/guides/using-ssh.rst
@@ -1,5 +1,5 @@
-Connecting to host via SSH
-##########################
+Using SSH
+#########
 
 You can use :class:`pytest_mh.ssh.SSHClient` to connect to any host as any
 user. It is not recommended to instantiate this class on yourself but you should


### PR DESCRIPTION
* the naming was a little inconsistent and looked strange, generalized some of the titles and files.