### PR TITLE
Make code compatible with latest pytest-mh changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jc
 pytest
 python-ldap
-pytest-mh >= 1.0.18
+pytest-mh >= 1.0.19

--- a/sssd_test_framework/config.py
+++ b/sssd_test_framework/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Tuple, Type
+from typing import Any, Mapping, Self, Tuple, Type
 
 import pytest
 from pytest_mh import (
@@ -99,7 +99,7 @@ class SSSDTopologyMark(TopologyMark):
         return d
 
     @classmethod
-    def CreateFromArgs(cls, item: pytest.Function, args: Tuple, kwargs: Mapping[str, Any]) -> TopologyMark:
+    def CreateFromArgs(cls, item: pytest.Function, args: Tuple, kwargs: Mapping[str, Any]) -> Self:
         """
         Create :class:`TopologyMark` from pytest.mark.topology arguments.
 
@@ -113,7 +113,7 @@ class SSSDTopologyMark(TopologyMark):
         :type item: pytest.Function
         :raises ValueError: If the marker is invalid.
         :return: Instance of TopologyMark.
-        :rtype: TopologyMark
+        :rtype: Self
         """
         # First three parameters are positional, the rest are keyword arguments.
         if len(args) != 2 and len(args) != 3:

--- a/sssd_test_framework/config.py
+++ b/sssd_test_framework/config.py
@@ -99,9 +99,9 @@ class SSSDTopologyMark(TopologyMark):
         return d
 
     @classmethod
-    def _CreateFromArgs(cls, item: pytest.Function, args: Tuple, kwargs: Mapping[str, Any]) -> TopologyMark:
+    def CreateFromArgs(cls, item: pytest.Function, args: Tuple, kwargs: Mapping[str, Any]) -> TopologyMark:
         """
-        Create :class:`TopologyMark` from pytest marker arguments.
+        Create :class:`TopologyMark` from pytest.mark.topology arguments.
 
         .. warning::
 

--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from pytest_mh.conn import ProcessLogLevel
 
-from .base import BaseBackupHost, BaseLinuxHost
+from .base import BaseHost, BaseLinuxHost
 
 __all__ = [
     "ClientHost",
 ]
 
 
-class ClientHost(BaseBackupHost, BaseLinuxHost):
+class ClientHost(BaseHost, BaseLinuxHost):
     """
     SSSD client host object.
 

--- a/sssd_test_framework/hosts/nfs.py
+++ b/sssd_test_framework/hosts/nfs.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from pytest_mh.conn import ProcessLogLevel
 
-from .base import BaseBackupHost, BaseLinuxHost
+from .base import BaseHost, BaseLinuxHost
 
 __all__ = [
     "NFSHost",
 ]
 
 
-class NFSHost(BaseBackupHost, BaseLinuxHost):
+class NFSHost(BaseHost, BaseLinuxHost):
     """
     NFS server host object.
 

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -58,8 +58,8 @@ class BackupTopologyController(TopologyController[SSSDMultihostConfig]):
         self.backup_data: dict[BaseBackupHost, Any | None] = {}
         self.provisioned: bool = False
 
-    def _init(self, *args, **kwargs):
-        super()._init(*args, **kwargs)
+    def init(self, *args, **kwargs):
+        super().init(*args, **kwargs)
         self.provisioned = self.name in self.multihost.provisioned_topologies
 
     def restore(self, hosts: dict[BaseBackupHost, Any | None]) -> None:

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from functools import partial, wraps
 from typing import Any
 
-from pytest_mh import TopologyController
+from pytest_mh import MultihostBackupHost, TopologyController
 from pytest_mh.conn import ProcessResult
 
 from .config import SSSDMultihostConfig
 from .hosts.ad import ADHost
-from .hosts.base import BaseBackupHost
 from .hosts.client import ClientHost
 from .hosts.ipa import IPAHost
 from .hosts.nfs import NFSHost
@@ -55,17 +54,17 @@ class BackupTopologyController(TopologyController[SSSDMultihostConfig]):
     def __init__(self) -> None:
         super().__init__()
 
-        self.backup_data: dict[BaseBackupHost, Any | None] = {}
+        self.backup_data: dict[MultihostBackupHost, Any | None] = {}
         self.provisioned: bool = False
 
     def init(self, *args, **kwargs):
         super().init(*args, **kwargs)
         self.provisioned = self.name in self.multihost.provisioned_topologies
 
-    def restore(self, hosts: dict[BaseBackupHost, Any | None]) -> None:
+    def restore(self, hosts: dict[MultihostBackupHost, Any | None]) -> None:
         errors = []
         for host, backup_data in hosts.items():
-            if not isinstance(host, BaseBackupHost):
+            if not isinstance(host, MultihostBackupHost):
                 continue
 
             try:
@@ -77,10 +76,10 @@ class BackupTopologyController(TopologyController[SSSDMultihostConfig]):
             raise ExceptionGroup("Some hosts failed to restore to original state", errors)
 
     def restore_vanilla(self) -> None:
-        restore_data: dict[BaseBackupHost, Any | None] = {}
+        restore_data: dict[MultihostBackupHost, Any | None] = {}
 
         for host in self.hosts:
-            if not isinstance(host, BaseBackupHost):
+            if not isinstance(host, MultihostBackupHost):
                 continue
 
             restore_data[host] = host.backup_data
@@ -93,7 +92,7 @@ class BackupTopologyController(TopologyController[SSSDMultihostConfig]):
 
         try:
             for host, backup_data in self.backup_data.items():
-                if not isinstance(host, BaseBackupHost):
+                if not isinstance(host, MultihostBackupHost):
                     continue
 
                 host.remove_backup(backup_data)


### PR DESCRIPTION
While rewriting pytest-mh documentation I realized that some methods
are marked with underscore to make them private, however, these methods
are actually expected to be overwritten. Therefore they should be public.

* https://github.com/next-actions/pytest-mh/pull/81
* https://github.com/next-actions/pytest-mh/pull/82

Additionally, I also make our backup code generic and pushed it into pytest-mh. This is not a breaking change, but it starts using this generic code instead of our own implementation.

* https://github.com/next-actions/pytest-mh/pull/79