### PR TITLE
hosts: Add restorecon to restore functions for ipa and client.

### DIFF
--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -145,6 +145,7 @@ class ClientHost(BaseBackupHost, BaseLinuxHost):
                 rm --force --recursive "$2"
                 if [ -d "$1" ] || [ -f "$1" ]; then
                     cp --force --archive "$1" "$2"
+                    restorecon -rf "$2"
                 fi
             }}
 


### PR DESCRIPTION
Make the restored config file have the right selinux context on client and ipa.