### PR TITLE
ipa: retry restore if it fails to bind to LDAP

### DIFF
--- a/sssd_test_framework/misc/ssh.py
+++ b/sssd_test_framework/misc/ssh.py
@@ -100,6 +100,7 @@ def retry_command(
     delay: float = 1,
     match_stdout: str | list[str] | None = None,
     match_stderr: str | list[str] | None = None,
+    check_rc: bool = True,
 ) -> Callable[[Callable[Param, ProcessResult]], Callable[Param, ProcessResult]]:
     """
     Decorated function will be retried if its return code is non zero.
@@ -112,7 +113,8 @@ def retry_command(
     :type match_stdout: str | list[str] | None, optional
     :param match_stderr: If set, retry only of string is found in stderr, defaults to None
     :type match_stderr: str | list[str] | None, optional
-
+    :param check_rc: If True and rc == 0, do not retry.
+    :type check_rc: bool
     :return: Decorated function.
     :rtype: Callable
     """
@@ -151,7 +153,7 @@ def retry_command(
                     stdout = e.stdout
                     stderr = e.stderr
 
-                if rc == 0:
+                if check_rc and rc == 0:
                     break
 
                 if match_stdout is not None and not _match(match_stdout, stdout):


### PR DESCRIPTION
ipa-restore sometimes returns 0 but does not restore IPA correctly.

```
+ ipa-restore --unattended --password Secret123 --data --online /tmp/tmp.aBMkEEeqbD/ipa
Preparing restore from /tmp/tmp.aBMkEEeqbD/ipa on master.ipa.test
Performing DATA restore from DATA backup
Temporary setting umask to 022
Each master will individually need to be re-initialized or
re-created from this one. The replication agreements on
masters running IPA 3.1 or earlier will need to be manually
re-enabled. See the man page for details.
Disabling all replication.
Starting Directory Server
Restoring from userRoot in IPA-TEST
Unable to bind to LDAP server: Operations error:
Restoring from ipaca in IPA-TEST
Waiting for LDIF to finish
Restoring umask to 18
The ipa-restore command was successful
```