### PR TITLE
sssd: disable interpolation for configparser

### DIFF
--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -692,7 +692,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
 
     def __set_debug_level(self, debug_level: str | None = None) -> configparser.ConfigParser:
         """Set debug level in all sections."""
-        cfg = configparser.ConfigParser()
+        cfg = configparser.ConfigParser(interpolation=None)
         cfg.read_dict(self.config)
 
         if debug_level is None:


### PR DESCRIPTION
Otherwise using percent sign will raise an error, e.g.:

```
client.sssd.domain["override_homedir"] = "/home/%u"
```

```
self = <configparser.BasicInterpolation object at 0x7fe0fcb46810>
parser = <configparser.ConfigParser object at 0x7fe0fca92fd0>
section = 'domain/test', option = 'override_homedir', value = '/home/%u'

    def before_set(self, parser, section, option, value):
        tmp_value = value.replace('%%', '') # escaped percent signs
        tmp_value = self._KEYCRE.sub('', tmp_value) # valid syntax
        if '%' in tmp_value:
>           raise ValueError("invalid interpolation syntax in %r at "
                             "position %d" % (value, tmp_value.find('%')))
E           ValueError: invalid interpolation syntax in '/home/%u' at position 6

/usr/lib64/python3.11/configparser.py:403: ValueError
```