### PR TITLE
roles: make naming_context a @property

### DIFF
--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -62,11 +62,6 @@ class AD(BaseWindowsRole[ADHost]):
         Active Directory domain name.
         """
 
-        self.naming_context: str = self.host.naming_context
-        """
-        Active Directory naming context.
-        """
-
         self.realm: str = self.host.realm
         """
         Kerberos realm.
@@ -126,6 +121,15 @@ class AD(BaseWindowsRole[ADHost]):
                     },
                 }
         """
+
+    @property
+    def naming_context(self) -> str:
+        """
+        Active Directory naming context.
+
+        :rtype: str
+        """
+        return self.host.naming_context
 
     def fqn(self, name: str) -> str:
         """

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -59,11 +59,6 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
         Samba domain name.
         """
 
-        self.naming_context: str = self.host.naming_context
-        """
-        Samba naming context.
-        """
-
         self.realm: str = self.host.realm
         """
         Kerberos realm.
@@ -123,6 +118,15 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
 
         # Set AD schema for automount
         self.automount.set_schema(self.automount.Schema.AD)
+
+    @property
+    def naming_context(self) -> str:
+        """
+        Samba naming context.
+
+        :rtype: str
+        """
+        return self.host.naming_context
 
     def fqn(self, name: str) -> str:
         """


### PR DESCRIPTION
Otherwise we use the ssh/ldap connection inside the constructor
which can cause troubles.