### PR TITLE
ipa: do not attempt to kinit if features are already detected

### DIFF
--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -72,12 +72,11 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
         """
         Features supported by the host.
         """
-        self.kinit()
-
         if self._features is not None:
             return self._features
 
         self.logger.info(f"Detecting features on {self.hostname}")
+        self.kinit()
 
         result = self.conn.run(
             """


### PR DESCRIPTION
kinit was run every time this property was accessed. This caused
"Calling exit but enter was not called" exception in pytest-mh
under special conditions:

- a test fails in a way that leaves IPA inoperable
- IPA restore does not work
- new test has `builtwith` marker that access IPA.features

In this case kinit was called, failed and exepction was thrown.
pytest-mh then skipped setup but attempted to teardown