### PR TITLE
utils sssd, adding clean flag, clearing the cache on starts and restarts

### DIFF
--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -113,6 +113,7 @@ class ClientHost(BaseHost, BaseLinuxHost):
             backup /etc/sssd "$path/config"
             backup /var/log/sssd "$path/logs"
             backup /var/lib/sss "$path/lib"
+            backup /home "$path/home"
 
             echo $path
             """,
@@ -148,12 +149,13 @@ class ClientHost(BaseHost, BaseLinuxHost):
                 fi
             }}
 
-            rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd
+            rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd /home
             restore "{backup_path}/krb5.conf" /etc/krb5.conf
             restore "{backup_path}/krb5.keytab" /etc/krb5.keytab
             restore "{backup_path}/config" /etc/sssd
             restore "{backup_path}/logs" /var/log/sssd
             restore "{backup_path}/lib" /var/lib/sss
+            restore "{backup_path}/home" /home
             """,
             log_level=ProcessLogLevel.Error,
         )

--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -900,20 +900,15 @@ class SSSDCommonConfiguration(object):
         self.sssd.authselect.select("sssd")
         self.sssd.enable_responder("autofs")
 
-    def mkhomedir(self, homedir: str = "/home") -> None:
+    def mkhomedir(self) -> None:
         """
         Configure SSSD with mkhomedir and oddjobd.
 
-        :param homedir: Home directory path.
-        :type homedir: str | None, optional
-
         #. Select authselect sssd profile with 'with-mkhomedir'
         #. Start oddjobd.service
-        #. Backup home directory
         """
         self.sssd.authselect.select("sssd", ["with-mkhomedir"])
         self.sssd.svc.start("oddjobd.service")
-        self.sssd.fs.backup(homedir)
 
     def proxy(
         self,

--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -119,6 +119,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         apply_config: bool = True,
         check_config: bool = True,
         debug_level: str | None = "0xfff0",
+        clean: bool = False,
     ) -> Process:
         """
         Start the SSSD and KCM services. Non-blocking call.
@@ -133,6 +134,8 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         :type check_config: bool, optional
         :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
+        :param clean: Does a clean restart, clearing the cache, defaults to False
+        :type clean: bool, defaults to False
         :return: Running SSH process.
         :rtype: Process
         """
@@ -145,6 +148,9 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         if service == "sssd":
             self.svc.async_stop("sssd-kcm.service")
 
+        if clean and service == "sssd":
+            self.clear()
+
         return self.svc.async_start(service)
 
     def start(
@@ -156,6 +162,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         apply_config: bool = True,
         check_config: bool = True,
         debug_level: str | None = "0xfff0",
+        clean: bool = False,
     ) -> ProcessResult:
         """
         Start the SSSD and KCM services. The call will wait until the operation is finished.
@@ -172,6 +179,8 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         :type check_config: bool, optional
         :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
+        :param clean: Does a clean restart, clearing the cache, defaults to False
+        :type clean: bool, defaults to False
         :return: SSH process result.
         :rtype: ProcessResult
         """
@@ -183,6 +192,9 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         # Also stop kcm so that it is started when first used.
         if service == "sssd":
             self.svc.stop("sssd-kcm.service")
+
+        if clean and service == "sssd":
+            self.clear()
 
         return self.svc.start(service, raise_on_error=raise_on_error)
 
@@ -225,6 +237,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         apply_config: bool = True,
         check_config: bool = True,
         debug_level: str | None = "0xfff0",
+        clean: bool = False,
     ) -> Process:
         """
         Restart the SSSD and KCM services. Non-blocking call.
@@ -237,6 +250,8 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         :type check_config: bool, optional
         :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
+        :param clean: Does a clean restart, clearing the cache, defaults to False
+        :type clean: bool, defaults to False
         :return: Running SSH process.
         :rtype: Process
         """
@@ -246,6 +261,9 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         # Also stop kcm so that it is started when first used.
         if service == "sssd":
             self.svc.async_stop("sssd-kcm.service")
+
+        if clean and service == "sssd":
+            self.clear()
 
         return self.svc.async_restart(service)
 
@@ -257,6 +275,7 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         apply_config: bool = True,
         check_config: bool = True,
         debug_level: str | None = "0xfff0",
+        clean: bool = False,
     ) -> ProcessResult:
         """
         Restart the SSSD and KCM services. The call will wait until the operation is finished.
@@ -271,6 +290,8 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         :type check_config: bool, optional
         :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
+        :param clean: Does a clean restart, clearing the cache, defaults to False
+        :type clean: bool, defaults to False
         :return: SSH process result.
         :rtype: ProcessResult
         """
@@ -280,6 +301,9 @@ class SSSDUtils(MultihostUtility[MultihostHost]):
         # Also stop kcm so that it is started when first used.
         if service == "sssd":
             self.svc.stop("sssd-kcm.service")
+
+        if clean and service == "sssd":
+            self.clear()
 
         return self.svc.restart(service, raise_on_error=raise_on_error)
 


### PR DESCRIPTION
Two commits:

1. Adding a clean parameter to mkhomedir common configuration, the override_homedirs are failing because some directories already exist from other tests.  After backing up homedir path, it will not clear it as well. 
2. Adding a clean parameter to sssd start, restart to condense 
```
client.sssd.stop()
client.sssd.clear()
client.sssd.start()
```
to 
```
client.sssd.restart(clean=True)
```
