### PR TITLE
roles, adding default domain password policy management 

### DIFF
--- a/sssd_test_framework/misc/__init__.py
+++ b/sssd_test_framework/misc/__init__.py
@@ -161,6 +161,22 @@ Param = ParamSpec("Param")
 RetType = TypeVar("RetType")
 
 
+def seconds_to_timespan(seconds: int) -> str:
+    """
+    Convert seconds to powershell timespan format, 'Days:Hours:Minutes:Seconds:Fractions'.
+
+    :param seconds: Seconds.
+    :type seconds: int
+    :return: Time in timespan format.
+    :rtype: str
+    """
+    m, s = divmod(seconds, 60)
+    h, m = divmod(m, 60)
+    d, h = divmod(h, 24)
+
+    return f"{d:02d}:{h:02d}:{m:02d}:{s:02d}:00"
+
+
 def retry(
     max_retries: int = 5,
     delay: float = 1,

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -934,7 +934,7 @@ class ADUser(ADObject):
 
         return self
 
-    def password_change_at_logon(self) -> ADUser:
+    def password_change_at_logon(self, **kwargs) -> ADUser:
         """
         Force user to change password next logon.
 

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -9,8 +9,9 @@ from pytest_mh.cli import CLIBuilderArgs
 from pytest_mh.conn import ProcessResult
 
 from ..hosts.ad import ADHost
-from ..misc import attrs_include_value, attrs_parse, attrs_to_hash
+from ..misc import attrs_include_value, attrs_parse, attrs_to_hash, seconds_to_timespan
 from .base import BaseObject, BaseWindowsRole, DeleteAttribute
+from .generic import GenericPasswordPolicy
 from .ldap import LDAPNetgroupMember
 from .nfs import NFSExport
 
@@ -24,6 +25,7 @@ __all__ = [
     "ADComputer",
     "ADSudoRule",
     "ADUser",
+    "ADPasswordPolicy",
     "GPO",
 ]
 
@@ -70,6 +72,9 @@ class AD(BaseWindowsRole[ADHost]):
 
         self.auto_ou: dict[str, bool] = {}
         """Organizational units that were automatically created."""
+
+        self._password_policy: ADPasswordPolicy = ADPasswordPolicy(self)
+        """Manage password policies."""
 
         self.automount: ADAutomount = ADAutomount(self)
         """
@@ -122,6 +127,30 @@ class AD(BaseWindowsRole[ADHost]):
                     },
                 }
         """
+
+    @property
+    def password_policy(self) -> ADPasswordPolicy:
+        """
+        Domain password policy management.
+
+        .. code-block:: python
+            :caption: Example usage
+
+            @pytest.mark.topology(KnownTopology.AD)
+            def test_example(client: Client, ad: AD):
+                # Enable password complexity
+                ad.password_policy.complexity(enable=True)
+
+                # Set 2 login attempts and 30 lockout duration
+                ad.password_policy.lockout(attempts=2, duration=30)
+
+                # Set password length requirement to 11 characters
+                ad.password_policy.requirement(length=11)
+
+                # Set password max age to 29 seconds
+                ad.password_policy.age(maximum=29)
+        """
+        return self._password_policy
 
     @property
     def naming_context(self) -> str:
@@ -908,6 +937,17 @@ class ADUser(ADObject):
 
         args = " ".join(self.cli.args(attrs, quote_value=True))
         self.role.host.conn.run(f"Set-ADAccountExpiration {args}")
+
+        return self
+
+    def password_change_at_logon(self) -> ADUser:
+        """
+        Force user to change password next logon.
+
+        :return: Self.
+        :rtype: ADUser
+        """
+        self.role.host.conn.run(f"Set-ADUser -Identity {self.name} -ChangePasswordAtLogon:$true")
 
         return self
 
@@ -2005,6 +2045,64 @@ class GPO(BaseObject[ADHost, AD]):
             Exit 0
             """
         )
+
+        return self
+
+
+class ADPasswordPolicy(GenericPasswordPolicy):
+    """
+    Password policy management.
+    """
+
+    def __init__(self, role: AD):
+        """
+        :param role: AD host object.
+        :type role: ADHost
+        """
+        super().__init__(role)
+
+        args: CLIBuilderArgs = {
+            "Identity": (self.cli.option.VALUE, self.role.domain),
+            "PasswordHistoryCount": (self.cli.option.VALUE, "0"),
+            "MinPasswordAge": (self.cli.option.VALUE, "0"),
+            "MaxPasswordAge": (self.cli.option.VALUE, "0"),
+        }
+        self.role.host.conn.run(self.cli.command("Set-ADDefaultDomainPasswordPolicy", args))
+
+    def complexity(self, enable: bool) -> ADPasswordPolicy:
+        """
+        Enable or disable password complexity.
+
+        :param enable: Enable or disable password complexity.
+        :type enable: bool
+        :return: ADPasswordPolicy object.
+        :rtype: ADPasswordPolicy
+        """
+        args: CLIBuilderArgs = {
+            "Identity": (self.cli.option.VALUE, self.role.domain),
+            "Complexity": (self.cli.option.SWITCH, enable),
+        }
+        self.role.host.conn.run(self.cli.command("Set-ADDefaultDomainPasswordPolicy", args))
+
+        return self
+
+    def lockout(self, duration: int, attempts: int) -> ADPasswordPolicy:
+        """
+        Set lockout duration and login attempts.
+
+        :param duration: Duration of lockout in seconds.
+        :type duration: int
+        :param attempts: Number of login attempts.
+        :type attempts: int
+        :return: ADPasswordPolicy object.
+        :rtype: ADPasswordPolicy
+        """
+        args: CLIBuilderArgs = {
+            "Identity": (self.cli.option.VALUE, self.role.domain),
+            "LockoutDuration": (self.cli.option.VALUE, seconds_to_timespan(duration)),
+            "LockoutThreshold": (self.cli.option.VALUE, str(attempts)),
+        }
+        self.role.host.conn.run(self.cli.command("Set-ADDefaultDomainPasswordPolicy", args))
 
         return self
 

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -143,12 +143,6 @@ class AD(BaseWindowsRole[ADHost]):
 
                 # Set 2 login attempts and 30 lockout duration
                 ad.password_policy.lockout(attempts=2, duration=30)
-
-                # Set password length requirement to 11 characters
-                ad.password_policy.requirement(length=11)
-
-                # Set password max age to 29 seconds
-                ad.password_policy.age(maximum=29)
         """
         return self._password_policy
 

--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -17,6 +17,7 @@ __all__ = [
     "GenericProvider",
     "GenericADProvider",
     "GenericOrganizationalUnit",
+    "GenericPasswordPolicy",
     "GenericUser",
     "GenericGroup",
     "GenericComputer",
@@ -74,6 +75,25 @@ class GenericProvider(ABC, MultihostRole[BaseHost]):
     @property
     @abstractmethod
     def firewall(self) -> Firewall:
+        pass
+
+    @property
+    @abstractmethod
+    def password_policy(self) -> GenericPasswordPolicy:
+        """
+        Domain password policy management.
+
+        .. code-block:: python
+            :caption: Example usage
+
+            @pytest.mark.topology(KnownTopologyGroup.Any)
+            def test_example(client: Client, provider: GenericProvider):
+                # Enable password complexity
+                provider.password_policy.complexity(enable=True)
+
+                # Set 3 login attempts and 30 lockout duration
+                provider.password_policy.lockout(attempts=3, duration=30)
+        """
         pass
 
     @abstractmethod
@@ -535,6 +555,16 @@ class GenericUser(ABC, BaseObject):
         :type expirataion: str, optional
         :return: Self.
         :rtype: IPAUser
+        """
+        pass
+
+    @abstractmethod
+    def password_change_at_logon(self) -> GenericUser:
+        """
+        Force user to change password next logon.
+
+        :return: Self.
+        :rtype: GenericUser
         """
         pass
 
@@ -1279,5 +1309,37 @@ class GenericGPO(
         :type cfg: dict[str, Any] | None
         :return: Self.
         :rtype: GenericGPO
+        """
+        pass
+
+
+class GenericPasswordPolicy(ABC, BaseObject):
+    """
+    Password policy management.
+    """
+
+    @abstractmethod
+    def complexity(self, enable: bool) -> GenericPasswordPolicy:
+        """
+        Enable or disable password complexity.
+
+        :param enable: Enable or disable password complexity.
+        :type enable: bool
+        :return: GenericPasswordPolicy object.
+        :rtype: GenericPasswordPolicy
+        """
+        pass
+
+    @abstractmethod
+    def lockout(self, duration: int, attempts: int) -> GenericPasswordPolicy:
+        """
+        Set lockout duration and login attempts.
+
+        :param duration: Duration of lockout in seconds.
+        :type duration: int
+        :param attempts: Number of login attempts.
+        :type attempts: int
+        :return: GenericPasswordPolicy object.
+        :rtype: GenericPasswordPolicy
         """
         pass

--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -559,9 +559,12 @@ class GenericUser(ABC, BaseObject):
         pass
 
     @abstractmethod
-    def password_change_at_logon(self) -> GenericUser:
+    def password_change_at_logon(self, **kwargs) -> GenericUser:
         """
         Force user to change password next logon.
+
+        The LDAP provider needs to administratively reset the user password to trigger the password
+        change. Making the key word argument 'password' required by LDAP but will be ignored by others..
 
         :return: Self.
         :rtype: GenericUser

--- a/sssd_test_framework/roles/ipa.py
+++ b/sssd_test_framework/roles/ipa.py
@@ -610,7 +610,7 @@ class IPAUser(IPAObject):
 
         return self
 
-    def password_change_at_logon(self) -> IPAUser:
+    def password_change_at_logon(self, **kwargs) -> IPAUser:
         """
         Force user to change password next logon.
 

--- a/sssd_test_framework/roles/ldap.py
+++ b/sssd_test_framework/roles/ldap.py
@@ -874,14 +874,18 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
 
         return self
 
-    def password_change_at_logon(self) -> LDAPUser:
+    def password_change_at_logon(self, **kwargs) -> LDAPUser:
         """
         Force user to change password next logon.
 
         :return: Self.
         :rtype: LDAPUser
         """
+        if "password" not in kwargs.keys():
+            raise TypeError("Missing argument 'password'!")
+
         self.role.ldap.modify("cn=config", replace={"passwordMustChange": "on"})
+        self.modify(password=kwargs["password"])
 
         return self
 

--- a/sssd_test_framework/roles/ldap.py
+++ b/sssd_test_framework/roles/ldap.py
@@ -14,11 +14,12 @@ from ..hosts.ldap import LDAPHost
 from ..misc import attrs_include_value, to_list_without_none
 from ..utils.ldap import LDAPRecordAttributes, LDAPUtils
 from .base import BaseLinuxLDAPRole, BaseObject, DeleteAttribute, HostType
-from .generic import GenericNetgroupMember, ProtocolName
+from .generic import GenericNetgroupMember, GenericPasswordPolicy, ProtocolName
 from .nfs import NFSExport
 
 __all__ = [
     "LDAPRoleType",
+    "LDAPPasswordPolicy",
     "LDAPUserType",
     "LDAPGroupType",
     "LDAP",
@@ -84,6 +85,9 @@ class LDAP(BaseLinuxLDAPRole[LDAPHost]):
         self.aci: LDAPACI = LDAPACI(self)
         """Manage LDAP ACI records."""
 
+        self._password_policy: LDAPPasswordPolicy = LDAPPasswordPolicy(self)
+        """Manage password policy."""
+
         self.automount: LDAPAutomount[LDAPHost, LDAP] = LDAPAutomount[LDAPHost, LDAP](self)
         """
         Manage automount maps and keys.
@@ -135,6 +139,24 @@ class LDAP(BaseLinuxLDAPRole[LDAPHost]):
                     },
                 }
         """
+
+    @property
+    def password_policy(self) -> LDAPPasswordPolicy:
+        """
+        Domain password policy management.
+
+        .. code-block:: python
+            :caption: Example usage
+
+            @pytest.mark.topology(KnownTopology.LDAP)
+            def test_example(client: Client, ldap: LDAP):
+                # Enable password complexity
+                ldap.password_policy.complexity(enable=True)
+
+                # Set 3 login attempts and 30 lockout duration
+                ldap.password_policy.lockout(attempts=3, duration=30)
+        """
+        return self._password_policy
 
     def _generate_uid(self) -> int:
         """
@@ -841,7 +863,6 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         :return: Self.
         :rtype: IPAUser
         """
-
         start = datetime.now()
         end = datetime.strptime(expiration, "%Y%m%d%H%M%S")
         time_diff = end - start
@@ -850,6 +871,17 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
             expires_in = 0
 
         self.modify(shadowMax=expires_in)
+
+        return self
+
+    def password_change_at_logon(self) -> LDAPUser:
+        """
+        Force user to change password next logon.
+
+        :return: Self.
+        :rtype: LDAPUser
+        """
+        self.role.ldap.modify("cn=config", replace={"passwordMustChange": "on"})
 
         return self
 
@@ -1766,3 +1798,84 @@ class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType]):
             return info.name
 
         return info
+
+
+class LDAPPasswordPolicy(GenericPasswordPolicy):
+    """
+    Password policy management.
+    """
+
+    def __init__(self, role: LDAP) -> None:
+        """
+        :param role: LDAP role object.
+        :type role: LDAP
+        """
+        super().__init__(role)
+        self.role: LDAP = role
+        self.ldap: LDAPUtils = self.role.ldap
+        self.config: str = "cn=config"
+
+        role.aci.add('(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)')
+
+    def _get(self, name: str) -> str:
+        """
+        Return password policy value.
+
+        :param name: Password policy setting name.
+        :type name: str
+        :return: Password policy value.
+        :rtype: str
+        """
+        result = (
+            self.ldap.conn.search_s(self.config, ldap.SCOPE_BASE, attrlist=[name])
+            .pop()[1]
+            .get(name)[0]
+            .decode("utf-8")
+        )
+        return result
+
+    def _set(self, policy: dict[str, str]) -> None:
+        """
+        Set password policy value.
+
+        :param policy: Password policy key and values.
+        :type policy: dict[str, str]
+        """
+        for k, v in policy.items():
+            if self._get(k) != v:
+                self.ldap.modify(self.config, replace={k: v})
+
+    def complexity(self, enable: bool) -> LDAPPasswordPolicy:
+        """
+        Enable or disable password complexity.
+
+        :param enable: Enable or disable password complexity.
+        :type enable: bool
+        :return: LDAPPasswordPolicy object.
+        :rtype: LDAPPasswordPolicy
+        """
+        if enable:
+            self._set({"passwordCheckSyntax": "on", "passwordMinLength": "8"})
+        else:
+            self._set({"passwordCheckSyntax": "off", "passwordMinLength": "0"})
+        return self
+
+    def lockout(self, duration: int, attempts: int) -> LDAPPasswordPolicy:
+        """
+        Set lockout duration and login attempts.
+
+        :param duration: Duration of lockout in seconds, converted to minutes.
+        :type duration: int
+        :param attempts: Number of login attempts.
+        :type attempts: int
+        :return: LDAPPasswordPolicy object.
+        :rtype: LDAPPasswordPolicy
+        """
+        self._set(
+            {
+                "passwordLockout": "on",
+                "passwordMaxFailure": str(attempts),
+                "passwordLockoutDuration": str(duration),
+            }
+        )
+        return self

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -698,7 +698,7 @@ class SambaUser(SambaObject):
         self._modify(attrs)
         return self
 
-    def password_change_at_logon(self) -> SambaUser:
+    def password_change_at_logon(self, **kwargs) -> SambaUser:
         """
         Force user to change password next logon.
 

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -14,12 +14,14 @@ from ..hosts.samba import SambaHost
 from ..misc import attrs_parse, to_list_of_strings
 from ..utils.ldap import LDAPRecordAttributes
 from .base import BaseLinuxLDAPRole, BaseObject, DeleteAttribute
+from .generic import GenericPasswordPolicy
 from .ldap import LDAPAutomount, LDAPNetgroup, LDAPNetgroupMember, LDAPObject, LDAPOrganizationalUnit, LDAPSudoRule
 
 __all__ = [
     "Samba",
     "SambaObject",
     "SambaComputer",
+    "SambaPasswordPolicy",
     "SambaUser",
     "SambaGroup",
     "SambaOrganizationalUnit",
@@ -62,6 +64,11 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
         self.realm: str = self.host.realm
         """
         Kerberos realm.
+        """
+
+        self._password_policy: SambaPasswordPolicy = SambaPasswordPolicy(self)
+        """
+        Samba password policy.
         """
 
         self.automount: SambaAutomount = SambaAutomount(self)
@@ -118,6 +125,24 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
 
         # Set AD schema for automount
         self.automount.set_schema(self.automount.Schema.AD)
+
+    @property
+    def password_policy(self) -> SambaPasswordPolicy:
+        """
+        Domain password policy management.
+
+        .. code-block:: python
+            :caption: Example usage
+
+            @pytest.mark.topology(KnownTopology.Samba)
+            def test_example(client: Client, samba: Samba):
+                # Enable password complexity
+                samba.password_policy.complexity(enable=True)
+
+                # Set 3 login attempts and 30 lockout duration
+                samba.password_policy.lockout(attempts=3, duration=30)
+        """
+        return self._password_policy
 
     @property
     def naming_context(self) -> str:
@@ -673,6 +698,16 @@ class SambaUser(SambaObject):
         self._modify(attrs)
         return self
 
+    def password_change_at_logon(self) -> SambaUser:
+        """
+        Force user to change password next logon.
+
+        :return: Self.
+        :rtype: SambaUser
+        """
+        self._modify({"pwdLastSet": "0"})
+        return self
+
     def passkey_add(self, passkey_mapping: str) -> SambaUser:
         """
         Add passkey mapping to the user.
@@ -1057,6 +1092,66 @@ class SambaGPO(SambaObject):
 
         self.role.fs.mkdir_p(_path, mode="750", user="BUILTIN\\administrators", group="users")
         self.role.fs.upload("/tmp/GptTmpl.inf", _full_path, mode="750", user="BUILTIN\\administrators", group="users")
+
+        return self
+
+
+class SambaPasswordPolicy(GenericPasswordPolicy):
+    """
+    Password policy management.
+    """
+
+    def __init__(self, role: Samba):
+        """
+        :param role: Samba host object.
+        :type role: SambaHost
+        """
+        super().__init__(role)
+
+        args: CLIBuilderArgs = {
+            "min-pwd-age": (self.cli.option.VALUE, "0"),
+            "max-pwd-age": (self.cli.option.VALUE, "0"),
+        }
+
+        self.host.conn.run(self.cli.command("samba-tool domain passwordsettings set", args))
+
+    def complexity(self, enable: bool) -> SambaPasswordPolicy:
+        """
+        Enable or disable password complexity.
+
+        :param enable: Enable or disable password complexity.
+        :type enable: bool
+        :return: SambaPasswordPolicy object.
+        :rtype: SambaPasswordPolicy
+        """
+        complexity: str = "on" if enable else "off"
+
+        args: CLIBuilderArgs = {
+            "complexity": (self.cli.option.VALUE, complexity),
+        }
+
+        self.host.conn.run(self.cli.command("samba-tool domain passwordsettings set", args))
+
+        return self
+
+    def lockout(self, duration: int, attempts: int) -> SambaPasswordPolicy:
+        """
+        Set lockout duration and login attempts.
+
+        :param duration: Duration of lockout in seconds, converted to minutes.
+        :type duration: int
+        :param attempts: Number of login attempts.
+        :type attempts: int
+        :return: SambaPasswordPolicy object.
+        :rtype: SambaPasswordPolicy
+        """
+        minutes = divmod(duration, 60)[0]
+
+        args: CLIBuilderArgs = {
+            "account-lockout-duration": (self.cli.option.VALUE, str(minutes)),
+            "account-lockout-threshold": (self.cli.option.VALUE, str(attempts)),
+        }
+        self.host.conn.run(self.cli.command("samba-tool domain passwordsettings set", args))
 
         return self
 

--- a/sssd_test_framework/utils/authentication.py
+++ b/sssd_test_framework/utils/authentication.py
@@ -284,6 +284,109 @@ class SUAuthenticationUtils(MultihostUtility[MultihostHost]):
         rc, _, _, _ = self.password_with_output(username, password)
         return rc == 0
 
+    def password_expired_with_output(
+        self, username: str, password: str, new_password: str
+    ) -> tuple[int, int, str, str]:
+        """
+        Call ``su - $username`` and authenticate the user with password, expect that the password
+        is expired and change it to the new password and captures standard output and error.
+
+        :param username: Username.
+        :type username: str
+        :param password: Old, expired user password.
+        :type password: str
+        :param new_password: New user password.
+        :type new_password: str
+        :return: Tuple containing [return code, command code, stdout, stderr].
+        :rtype: Tuple[int, int, str, str]
+        """
+        result = self.host.conn.expect_nobody(
+            rf"""
+            # Disable debug output
+            # exp_internal 0
+
+            proc exitmsg {{ msg code }} {{
+                # Close spawned program, if we are in the prompt
+                catch close
+
+                # Wait for the exit code
+                lassign [wait] pid spawnid os_error_flag rc
+
+                puts ""
+                puts "expect result: $msg"
+                puts "expect exit code: $code"
+                puts "expect spawn exit code: $rc"
+                exit $code
+            }}
+
+            # It takes some time to get authentication failure
+            set timeout {DEFAULT_AUTHENTICATION_TIMEOUT}
+            set prompt "\n.*\[#\$>\] $"
+            log_user 1
+            log_file /tmp/expect.log
+
+            spawn su - "{username}"
+
+            expect {{
+                "Password:" {{send "{password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "Password expired. Change your password now." {{ }}
+                -re $prompt {{exitmsg "Authentication succeeded without password change" 2}}
+                "Authentication failure" {{exitmsg "Authentication failure" 1}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "Current Password:" {{send "{password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "New password:" {{send "{new_password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "Retype new password:" {{send "{new_password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                -re $prompt {{exitmsg "Password change was successful" 0}}
+                "Please make sure the password meets the complexity constraints." {{exitmsg "Complexity failure" 1}}
+                "Password too short" {{exitmsg "Complexity failure" 1}}
+                "Password is too short" {{exitmsg "Complexity failure" 1}}
+                "Failed to update password" {{exitmsg "Password change failed" 1}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            exitmsg "Unexpected code path" 203
+        """,
+            verbose=False,
+        )
+
+        if result.rc > 200:
+            raise ExpectScriptError(result.rc)
+
+        expect_data = result.stdout_lines[-3:]
+
+        # Get command exit code.
+        cmdrc = int(expect_data[2].split(":")[1].strip())
+
+        # Alter stdout, first line is spawned command, the last three are our expect output.
+        stdout = "\n".join(result.stdout_lines[1:-3])
+
+        return result.rc, cmdrc, stdout, result.stderr
+
     def password_expired(self, username: str, password: str, new_password: str) -> bool:
         """
         Call ``su - $username`` and authenticate the user with password, expect
@@ -295,64 +398,11 @@ class SUAuthenticationUtils(MultihostUtility[MultihostHost]):
         :type password: str
         :param new_password: New user password.
         :type new_password: str
-        :return: True if authentication and password change was successful, False otherwise.
+        :return: True if password change is successful.
         :rtype: bool
         """
-        result = self.host.conn.expect_nobody(
-            rf"""
-            # It takes some time to get authentication failure
-            set timeout {DEFAULT_AUTHENTICATION_TIMEOUT}
-            set prompt "\n.*\[#\$>\] $"
-
-            spawn su - "{username}"
-
-            expect {{
-                "Password:" {{send "{password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "Password expired. Change your password now." {{ }}
-                -re $prompt {{puts "expect result: Authentication succeeded without password change"; exit 2}}
-                "Authentication failure" {{puts "expect result: Authentication failure"; exit 1}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "Current Password:" {{send "{password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "New password:" {{send "{new_password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "Retype new password:" {{send "{new_password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                -re $prompt {{puts "expect result: Password change was successful"; exit 0}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            puts "expect result: Unexpected code path"
-            exit 203
-        """
-        )
-
-        if result.rc > 200:
-            raise ExpectScriptError(result.rc)
-
-        return result.rc == 0
+        rc, _, _, _ = self.password_expired_with_output(username, password, new_password)
+        return rc == 0
 
     def passkey_with_output(
         self,
@@ -694,6 +744,106 @@ class SSHAuthenticationUtils(MultihostUtility[MultihostHost]):
         rc, _, _, _ = self.password_with_output(username, password, hostname)
         return rc == 0
 
+    def password_expired_with_output(
+        self, username: str, password: str, new_password: str, hostname: str = "localhost"
+    ) -> tuple[int, int, str, str]:
+        """
+        SSH to the remote host and authenticate the user with password, expect that the password
+        is expired and change it to the new password and captures standard output and error.
+
+        :param username: Username.
+        :type username: str
+        :param password: Old, expired user password.
+        :type password: str
+        :param new_password: New user password.
+        :type new_password: str
+        :param hostname: The hostname to connect to.
+        :type hostname: str
+        :return: Tuple containing [except return code, command exit code, stdout, stderr].
+        :rtype: Tuple[int, int, str, str]
+        """
+        result = self.host.conn.expect_nobody(
+            rf"""
+            # Disable debug output
+            exp_internal 0
+
+            proc exitmsg {{ msg code }} {{
+                # Close spawned program, if we are in the prompt
+                catch close
+
+                # Wait for the exit code
+                lassign [wait] pid spawnid os_error_flag rc
+
+                puts ""
+                puts "expect result: $msg"
+                puts "expect exit code: $code"
+                puts "expect spawn exit code: $rc"
+                exit $code
+            }}
+
+            # It takes some time to get authentication failure
+            set timeout {DEFAULT_AUTHENTICATION_TIMEOUT}
+            set prompt "\n.*\[#\$>\] $"
+            log_user 1
+            log_file /tmp/expect.log
+
+            spawn ssh {self.opts} \
+                -o PreferredAuthentications=password \
+                -o NumberOfPasswordPrompts=1 \
+                -l "{username}" "{hostname}"
+
+            expect {{
+                "password:" {{send "{password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "Current Password:" {{send "{password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "New password:" {{send "{new_password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "Retype new password:" {{send "{new_password}\n"}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            expect {{
+                "password updated successfully" {{exitmsg "Password change was successful" 0}}
+                "Please make sure the password meets the complexity constraints." {{exitmsg "Complexity failure" 1}}
+                "Password too short" {{exitmsg "Complexity failure" 1}}
+                "Password is too short" {{exitmsg "Complexity failure" 1}}
+                "Failed to update password" {{exitmsg "Password change failed" 1}}
+                timeout {{exitmsg "Unexpected output" 201}}
+                eof {{exitmsg "Unexpected end of file" 202}}
+            }}
+
+            exitmsg "Unexpected code path" 203
+            """,
+            verbose=False,
+        )
+
+        if result.rc > 200:
+            raise ExpectScriptError(result.rc)
+
+        expect_data = result.stdout_lines[-3:]
+
+        # Get command exit code.
+        cmdrc = int(expect_data[2].split(":")[1].strip())
+
+        # Alter stdout, first line is spawned command, the last three are our expect output.
+        stdout = "\n".join(result.stdout_lines[1:-3])
+
+        return result.rc, cmdrc, stdout, result.stderr
+
     def password_expired(self, username: str, password: str, new_password: str, hostname: str = "localhost") -> bool:
         """
         SSH to the remote host and authenticate the user with password, expect
@@ -710,69 +860,8 @@ class SSHAuthenticationUtils(MultihostUtility[MultihostHost]):
         :return: True if authentication and password change was successful, False otherwise.
         :rtype: bool
         """
-        result = self.host.conn.expect_nobody(
-            rf"""
-            # It takes some time to get authentication failure
-            set timeout {DEFAULT_AUTHENTICATION_TIMEOUT}
-            set prompt "\n.*\[#\$>\] $"
-
-            spawn ssh {self.opts} \
-                -o PreferredAuthentications=password \
-                -o NumberOfPasswordPrompts=1 \
-                -l "{username}" "{hostname}"
-
-            expect {{
-                "password:" {{send "{password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "Password expired. Change your password now." {{ }}
-                -re $prompt {{puts "expect result: Authentication succeeded without password change"; exit 2}}
-                "{username}@{hostname}: Permission denied" {{puts "expect result: Authentication failure"; exit 1}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "Current Password:" {{send "{password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "New password:" {{send "{new_password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                "Retype new password:" {{send "{new_password}\n"}}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                -re "passwd: .+ updated successfully." {{ }}
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Unexpected end of file"; exit 202}}
-            }}
-
-            expect {{
-                timeout {{puts "expect result: Unexpected output"; exit 201}}
-                eof {{puts "expect result: Password change was successful"; exit 0}}
-            }}
-
-            puts "expect result: Unexpected code path"
-            exit 203
-        """
-        )
-
-        if result.rc > 200:
-            raise ExpectScriptError(result.rc)
-
-        return result.rc == 0
+        rc, _, _, _ = self.password_expired_with_output(username, password, new_password, hostname)
+        return rc == 0
 
 
 class SudoAuthenticationUtils(MultihostUtility[MultihostHost]):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,6 +13,7 @@ from sssd_test_framework.misc import (
     attrs_to_hash,
     parse_ldif,
     retry,
+    seconds_to_timespan,
     to_list,
     to_list_of_strings,
     to_list_without_none,
@@ -241,6 +242,25 @@ def test_parse_ldif(value, expected):
 )
 def test_attrs_to_hash(value, expected):
     assert attrs_to_hash(value) == expected
+
+
+@pytest.mark.parametrize(
+    "seconds",
+    [
+        (0, "00:00:00:00:00"),
+        (9, "00:00:00:09:00"),
+        (59, "00:00:00:59:00"),
+        (60, "00:00:01:00:00"),
+        (61, "00:00:01:01:00"),
+        (119, "00:00:01:59:00"),
+        (600, "00:00:10:00:00"),
+        (601, "00:00:10:01:00"),
+        (3600, "00:01:00:00:00"),
+        (3601, "00:01:00:01:00"),
+    ],
+)
+def test_seconds_to_timespan(seconds: tuple[int, str]):
+    assert seconds_to_timespan(seconds[0]) == seconds[1]
 
 
 def test_retry__all_exceptions():


### PR DESCRIPTION
Tests PR, https://github.com/SSSD/sssd/pull/7728

This PR is larger than I expected. 

**misc.py**
* added seconds to timespan method and test, timespan is the powershell M:D:H:S:F format 

**authentication.py**
* SUAuthentication, added password_expired_with_output
* SSHAuthentication, added password_expired_with_output
* like password_with_out, replaced put with a valid {{exitmsg}}

**roles/ad.py, roles/ipa.py, roles/samba.py, roles/ldap.py**
* added PasswordPolicy class
* password.lockout(duration, attempts)
* password.complexity(enable)
* additionally to LDAP, added  password.get() and password.set() and added ACI to the password constructor. 

**roles/generic.py**
* added GenericPasswordPolicy class

