### PR TITLE
hosts: fix docstring

### DIFF
--- a/sssd_test_framework/hosts/base.py
+++ b/sssd_test_framework/hosts/base.py
@@ -270,7 +270,8 @@ class BaseLinuxHost(MultihostHost[SSSDMultihostDomain]):
     def get_package_version(self, package: str = "sssd", raise_on_error: bool = True) -> dict:
         """
         Parse package version and return it as a dictionary with:
-            major, minor, patch, prerelease, update, release
+        major, minor, patch, prerelease, update, release
+
         :param package: package name
         :param raise_on_error: raise exeption when package is missing
         :return: version dictionary


### PR DESCRIPTION
This docstring produced sphinx warning:

```
/home/runner/work/sssd-test-framework/sssd-test-framework/sssd_test_framework/hosts/base.py:docstring of sssd_test_framework.hosts.base.BaseLinuxHost.get_package_version:3: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
```