### PR TITLE
ipa-trust marks topology rename

### DIFF
--- a/sssd_test_framework/topology.py
+++ b/sssd_test_framework/topology.py
@@ -97,7 +97,7 @@ class KnownTopology(KnownTopologyBase):
     """
 
     IPATrustAD = SSSDTopologyMark(
-        name="ipa-trust-ad",
+        name="ad",
         topology=Topology(TopologyDomain("sssd", client=1, ipa=1, ad=1)),
         controller=IPATrustADTopologyController(),
         domains=dict(test="sssd.ipa[0]"),
@@ -108,7 +108,7 @@ class KnownTopology(KnownTopologyBase):
     """
 
     IPATrustSamba = SSSDTopologyMark(
-        name="ipa-trust-samba",
+        name="samba",
         topology=Topology(TopologyDomain("sssd", client=1, ipa=1, samba=1)),
         controller=IPATrustSambaTopologyController(),
         domains=dict(test="sssd.ipa[0]"),


### PR DESCRIPTION
Proposing the name change so we can specify the topology using '--mh-topology=samba' instead of '--mh-topology=ipa-trust-samba'. 