### PR TITLE
hosts: client, do not delete /home during restore

### DIFF
--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -149,13 +149,13 @@ class ClientHost(BaseHost, BaseLinuxHost):
                 fi
             }}
 
-            rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd /home
+            rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd /home/*
             restore "{backup_path}/krb5.conf" /etc/krb5.conf
             restore "{backup_path}/krb5.keytab" /etc/krb5.keytab
             restore "{backup_path}/config" /etc/sssd
             restore "{backup_path}/logs" /var/log/sssd
             restore "{backup_path}/lib" /var/lib/sss
-            restore "{backup_path}/home" /home
+            cp --force --archive "{backup_path}/home/*" /home/ || :
             """,
             log_level=ProcessLogLevel.Error,
         )


### PR DESCRIPTION
The /home is mountpoint so deleting it on real machine for backup and restore does not work in idmci.