### PR TITLE
tools.py - grep

### DIFF
--- a/sssd_test_framework/utils/tools.py
+++ b/sssd_test_framework/utils/tools.py
@@ -511,7 +511,7 @@ class LinuxToolsUtils(MultihostUtility[MultihostHost]):
             args = []
 
         paths = [paths] if isinstance(paths, str) else paths
-        command = self.host.conn.exec(["grep", *args, pattern, *paths])
+        command = self.host.conn.exec(["grep", *args, pattern, *paths], raise_on_error=False)
 
         return command.rc == 0
 


### PR DESCRIPTION
Grep should return False when pattern is not present, not raise an exception.