### PR TITLE
Add email attribute to GenericUser

### DIFF
--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -452,6 +452,7 @@ class GenericUser(ABC, BaseObject):
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
+        email: str | None = None,
     ) -> GenericUser:
         """
         Create a new user.
@@ -470,6 +471,8 @@ class GenericUser(ABC, BaseObject):
         :type gecos: str | None, optional
         :param shell: Login shell, defaults to None
         :type shell: str | None, optional
+        :param email: email attribute, defaults to None
+        :type email: str | None, optional
         :return: Self.
         :rtype: GenericUser
         """
@@ -485,6 +488,7 @@ class GenericUser(ABC, BaseObject):
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
+        email: str | None = None,
     ) -> GenericUser:
         """
         Modify existing user.
@@ -503,6 +507,8 @@ class GenericUser(ABC, BaseObject):
         :type gecos: str | None, optional
         :param shell: Login shell, defaults to None
         :type shell: str | None, optional
+        :param email: email attribute, defaults to None
+        :type email: str | None, optional
         :return: Self.
         :rtype: GenericUser
         """

--- a/sssd_test_framework/roles/ipa.py
+++ b/sssd_test_framework/roles/ipa.py
@@ -432,6 +432,7 @@ class IPAUser(IPAObject):
         require_password_reset: bool = False,
         user_auth_type: str | list[str] | None = None,
         sshpubkey: str | list[str] | None = None,
+        email: str | None = None,
     ) -> IPAUser:
         """
         Create new IPA user.
@@ -456,9 +457,12 @@ class IPAUser(IPAObject):
         :type user_auth_type: str | list[str] | None, optional
         :param sshpubkey: SSH public key, defaults to None
         :type sshpubkey: str | list[str] | None, optional
+        :param email: email attribute, defaults to None
+        :type email: str | None, optional
         :return: Self.
         :rtype: IPAUser
         """
+
         attrs = {
             "first": (self.cli.option.VALUE, self.name),
             "last": (self.cli.option.VALUE, self.name),
@@ -470,6 +474,7 @@ class IPAUser(IPAObject):
             "password": (self.cli.option.SWITCH, True) if password is not None else None,
             "user-auth-type": (self.cli.option.VALUE, user_auth_type),
             "sshpubkey": (self.cli.option.VALUE, sshpubkey),
+            "email": (self.cli.option.VALUE, email),
         }
 
         if not require_password_reset:
@@ -494,6 +499,7 @@ class IPAUser(IPAObject):
         idp_user_id: str | None = None,
         password_expiration: str | None = None,
         sshpubkey: str | list[str] | None = None,
+        email: str | None = None,
     ) -> IPAUser:
         """
         Modify existing IPA user.
@@ -524,6 +530,8 @@ class IPAUser(IPAObject):
         :type password_expiration: str | None, optional
         :param sshpubkey: SSH public key, defaults to None
         :type sshpubkey: str | list[str] | None, optional
+        :param email: email attribute, defaults to None
+        :type email: str | None, optional
         :return: Self.
         :rtype: IPAUser
         """
@@ -541,6 +549,7 @@ class IPAUser(IPAObject):
             "idp-user-id": (self.cli.option.VALUE, idp_user_id),
             "password-expiration": (self.cli.option.VALUE, password_expiration),
             "sshpubkey": (self.cli.option.VALUE, sshpubkey),
+            "email": (self.cli.option.VALUE, email),
         }
 
         self._modify(attrs, input=password)

--- a/sssd_test_framework/roles/ldap.py
+++ b/sssd_test_framework/roles/ldap.py
@@ -664,7 +664,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         shadowLastChange: int | None = None,
         sn: str | None = None,
         givenName: str | None = None,
-        mail: str | None = None,
+        mail: str | None = None,  # Remove later once tests are using the email attribute instead of mail
+        email: str | None = None,
     ) -> LDAPUser:
         """
         Create new LDAP user.
@@ -698,6 +699,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         :type givenName: str | None, optional
         :param mail: mail LDAP attribute, defaults to None
         :type mail: str | None, optional
+        :param email: mail LDAP attribute, defaults to None
+        :type mail: str | None, optional
         :return: Self.
         :rtype: LDAPUser
         """
@@ -725,13 +728,13 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
             "shadowLastChange": shadowLastChange,
             "sn": sn,
             "givenName": givenName,
-            "mail": mail,
+            "mail": mail or email,
         }
 
         if to_list_without_none([shadowMin, shadowMax, shadowWarning, shadowLastChange]):
             attrs["objectClass"].append("shadowAccount")
 
-        if to_list_without_none([sn, mail]):
+        if to_list_without_none([sn, mail, email]):
             attrs["sn"] = sn if sn else str(uid)
             attrs["objectClass"].append("inetOrgPerson")
 
@@ -755,6 +758,7 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         sn: str | DeleteAttribute | None = None,
         givenName: str | DeleteAttribute | None = None,
         mail: str | DeleteAttribute | None = None,
+        email: str | DeleteAttribute | None = None,
     ) -> LDAPUser:
         """
         Modify existing LDAP user.
@@ -790,9 +794,12 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         :type givenName: str | DeleteAttribute | None, optional
         :param mail: mail LDAP attribute, defaults to None
         :type mail: str | DeleteAttribute | None, optional
+        :param email: mail LDAP attribute, defaults to None
+        :type mail: str | DeleteAttribute | None, optional
         :return: Self.
         :rtype: LDAPUser
         """
+
         attrs: LDAPRecordAttributes = {
             "uidNumber": uid,
             "gidNumber": gid,
@@ -807,7 +814,7 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
             "cn": cn,
             "sn": sn,
             "givenName": givenName,
-            "mail": mail,
+            "mail": mail or email,
         }
 
         self._set(attrs)


### PR DESCRIPTION
- Adding email attribute to GenericUser;
- Keeping mail and email (retro-compatibility) for LDAP tests while we standardize it. I'll open a new PR to remove the mail and keep it there to be merged after we deal with sssd tests.