### PR TITLE
ipa: improvements to IPA artifacts

### DIFF
--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -99,6 +99,20 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
 
         return self._features
 
+    def setup(self) -> None:
+        """
+        Truncate existing IPA logs before each test to avoid need for restart.
+        """
+        self.conn.run(
+            """
+            set -ex
+            truncate --size 0 /var/log/dirsrv/*/*
+            truncate --size 0 /var/log/httpd/*
+            truncate --size 0 /var/log/ipa/*
+            truncate --size 0 /var/log/krb5kdc.log
+            """
+        )
+
     def kinit(self) -> None:
         """
         Obtain ``admin`` user Kerberos TGT.

--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -135,7 +135,7 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
                     fi
                 }
 
-                ipa-backup --data --online
+                ipa-backup --data
 
                 path=`mktemp -d`
                 mv `find /var/lib/ipa/backup -maxdepth 1 -type d | tail -n 1` $path/ipa
@@ -184,7 +184,7 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
                     fi
                 }}
 
-                ipa-restore --unattended --password "{self.adminpw}" --data --online "{backup_path}/ipa"
+                ipa-restore --unattended --password "{self.adminpw}" --data "{backup_path}/ipa"
 
                 rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd
                 restore "{backup_path}/krb5.conf" /etc/krb5.conf


### PR DESCRIPTION
```
6f42391 (Pavel Březina, 24 hours ago)
   ipa: truncate logs before each test

   So we can collect fresh logs from each test run. We use truncate insted of
   rm to avoid additional and time consuming IPA service restart.

0635309 (Pavel Březina, 24 hours ago)
   ipa: print backup and restore logs on failure

   These commands fail from time to time, it may be good to have more 
   information then the output.

353c783 (Pavel Březina, 24 hours ago)
   ipa: perform offline backup and restore

   It does not seem to have any performance impact anymore and may be more
   reliable then online backup and restore.
```