### PR TITLE
Uniform admin user declaration

### DIFF
--- a/sssd_test_framework/hosts/ad.py
+++ b/sssd_test_framework/hosts/ad.py
@@ -43,6 +43,9 @@ class ADHost(BaseDomainHost):
         self.adminpw: str = self.config.get("adminpw", "Secret123")
         """Password of the Administrator user, defaults to ``Secret123``."""
 
+        self.adminuser: str = self.config.get("adminuser", "administrator")
+        """Administrator user, defaults to ``administrator``."""
+
         # Additional client configuration
         self.client.setdefault("id_provider", "ad")
         self.client.setdefault("access_provider", "ad")

--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -51,6 +51,9 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
         self.adminpw: str = self.config.get("adminpw", "Secret123")
         """Password of the admin user, defaults to ``Secret123``."""
 
+        self.adminuser: str = self.config.get("adminuser", "admin")
+        """Administrator user, defaults to ``admin``."""
+
         self._features: dict[str, bool] | None = None
 
         # Additional client configuration

--- a/sssd_test_framework/hosts/samba.py
+++ b/sssd_test_framework/hosts/samba.py
@@ -30,7 +30,7 @@ class SambaHost(BaseLDAPDomainHost, BaseLinuxHost):
 
         self._features: dict[str, bool] | None = None
 
-        self.admin: str = self.config.get("username", "Administrator")
+        self.adminuser: str = self.config.get("username", "Administrator")
         """Username of the admin user, defaults to value of ``Administrator``."""
 
         self.adminpw: str = self.config.get("adminpw", self.bindpw)

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -937,7 +937,7 @@ class SambaGPO(SambaObject):
         """Group policy search base."""
 
         # samba-tool gpo commands edit the database files directly and need to be authenticated.
-        self.credentials: str = f" --username={self.role.host.admin} --password={self.role.host.adminpw}"
+        self.credentials: str = f" --username={self.role.host.adminuser} --password={self.role.host.adminpw}"
         """Credentials to manage GPOs."""
 
     def add(self) -> SambaGPO:
@@ -986,7 +986,7 @@ class SambaGPO(SambaObject):
             "Guid": (self.cli.option.POSITIONAL, self.cn),
             "enforce": (self.cli.option.SWITCH, enforced),
             "disable": (self.cli.option.SWITCH, disabled),
-            "username": (self.cli.option.VALUE, self.role.host.admin),
+            "username": (self.cli.option.VALUE, self.role.host.adminuser),
             "password": (self.cli.option.VALUE, self.role.host.adminpw),
         }
 


### PR DESCRIPTION
Declaring an administrative user across ad, ipa, samba hosts. This uniform declaration will help to use admin user intuitively in tests