### PR TITLE
changing client backup restore order

### DIFF
--- a/sssd_test_framework/hosts/client.py
+++ b/sssd_test_framework/hosts/client.py
@@ -149,13 +149,13 @@ class ClientHost(BaseHost, BaseLinuxHost):
                 fi
             }}
 
+            cp --force --archive "{backup_path}/home/*" /home/ || :
             rm --force --recursive /etc/sssd /var/lib/sss /var/log/sssd /home/*
             restore "{backup_path}/krb5.conf" /etc/krb5.conf
             restore "{backup_path}/krb5.keytab" /etc/krb5.keytab
             restore "{backup_path}/config" /etc/sssd
             restore "{backup_path}/logs" /var/log/sssd
             restore "{backup_path}/lib" /var/lib/sss
-            cp --force --archive "{backup_path}/home/*" /home/ || :
             """,
             log_level=ProcessLogLevel.Error,
         )


### PR DESCRIPTION
hitting a race condition causing authselect restore to fail because the home directory, containing the backup does not exist.