### PR TITLE
abstracting common variables and methods between all roles

### DIFF
--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -70,6 +70,16 @@ class AD(BaseWindowsRole[ADHost]):
         Kerberos realm.
         """
 
+        self.name: str = "ad"
+        """
+        Generic provider name.
+        """
+
+        self.server: str = self.host.hostname
+        """
+        Generic server name.
+        """
+
         self.auto_ou: dict[str, bool] = {}
         """Organizational units that were automatically created."""
 
@@ -160,6 +170,12 @@ class AD(BaseWindowsRole[ADHost]):
         Return fully qualified name in form name@domain.
         """
         return f"{name}@{self.domain}"
+
+    def dn(self, name: str) -> str:
+        """
+        Returns distinguished name in form of cn=name,naming_context.
+        """
+        return f"cn={name},{self.naming_context}"
 
     def user(self, name: str, basedn: ADObject | str | None = "cn=users") -> ADUser:
         """

--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -69,6 +69,30 @@ class GenericProvider(ABC, MultihostRole[BaseHost]):
 
     @property
     @abstractmethod
+    def name(self) -> str:
+        """
+        Generic provider name.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def server(self) -> str:
+        """
+        Generic server hostname.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def naming_context(self) -> str:
+        """
+        Naming context.
+        """
+        pass
+
+    @property
+    @abstractmethod
     def features(self) -> dict[str, Any]:
         pass
 
@@ -93,6 +117,22 @@ class GenericProvider(ABC, MultihostRole[BaseHost]):
 
                 # Set 3 login attempts and 30 lockout duration
                 provider.password_policy.lockout(attempts=3, duration=30)
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def fqn(self) -> str:
+        """
+        Return fully qualified name.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def dn(self) -> str:
+        """
+        Returns distinguished name.
         """
         pass
 
@@ -300,17 +340,11 @@ class GenericADProvider(GenericProvider):
         """
         pass
 
+    @property
     @abstractmethod
-    def fqn(self, name: str) -> str:
+    def fqn(self) -> str:
         """
         Return fully qualified name in form name@domain.
-        """
-        pass
-
-    @abstractmethod
-    def naming_context(self) -> str:
-        """
-        Return domain naming context in form of dc=domain,dc=com.
         """
         pass
 

--- a/sssd_test_framework/roles/ipa.py
+++ b/sssd_test_framework/roles/ipa.py
@@ -65,6 +65,16 @@ class IPA(BaseLinuxRole[IPAHost]):
         Kerberos realm.
         """
 
+        self.name: str = "ipa"
+        """
+        Generic provider name.
+        """
+
+        self.server: str = self.host.hostname
+        """
+        Generic server name.
+        """
+
         self.sssd: SSSDUtils = SSSDUtils(self.host, self.fs, self.svc, self.authselect, load_config=True)
         """
         Managing and configuring SSSD.
@@ -154,12 +164,36 @@ class IPA(BaseLinuxRole[IPAHost]):
         """
         return self._password_policy
 
+    @property
+    def naming_context(self) -> str:
+        """
+        LDAP  suffix.
+        """
+        if len(self.host.domain.split(".")) < 1:
+            raise IndexError("Second level domain missing!")
+
+        tld = self.host.domain.split(".")[-1]
+        sld = self.host.domain.split(".")[-2]
+        return f"dc={sld},dc={tld}"
+
     def setup(self) -> None:
         """
         Obtain IPA admin Kerberos TGT.
         """
         super().setup()
         self.host.kinit()
+
+    def fqn(self, name: str) -> str:
+        """
+        Return fully qualified name in form name@domain.
+        """
+        return f"{name}@{self.domain}"
+
+    def dn(self, name: str) -> str:
+        """
+        Returns distinguished name in form of cn=name,naming_context.
+        """
+        return f"cn={name},{self.naming_context}"
 
     def user(self, name: str) -> IPAUser:
         """

--- a/sssd_test_framework/roles/ldap.py
+++ b/sssd_test_framework/roles/ldap.py
@@ -76,6 +76,16 @@ class LDAP(BaseLinuxLDAPRole[LDAPHost]):
         Kerberos realm.
         """
 
+        self.name: str = "ldap"
+        """
+        Generic provider name.
+        """
+
+        self.server: str = self.host.hostname
+        """
+        Generic server name.
+        """
+
         self.auto_uid: int = 23000
         """The next automatically assigned user id."""
 
@@ -158,6 +168,18 @@ class LDAP(BaseLinuxLDAPRole[LDAPHost]):
         """
         return self._password_policy
 
+    @property
+    def naming_context(self) -> str:
+        """
+        LDAP  suffix.
+        """
+        if len(self.host.domain.split(".")) < 1:
+            raise IndexError("Second level domain missing!")
+
+        tld = self.host.domain.split(".")[-1]
+        sld = self.host.domain.split(".")[-2]
+        return f"dc={sld},dc={tld}"
+
     def _generate_uid(self) -> int:
         """
         Generate next user id value.
@@ -218,6 +240,18 @@ class LDAP(BaseLinuxLDAPRole[LDAPHost]):
             )
         except ldap.TYPE_OR_VALUE_EXISTS:
             pass
+
+    def fqn(self, name: str) -> str:
+        """
+        Return fully qualified name in form name@domain.
+        """
+        return f"{name}@{self.domain}"
+
+    def dn(self, name: str) -> str:
+        """
+        Returns distinguished name in form of cn=name,naming_context.
+        """
+        return f"cn={name},{self.naming_context}"
 
     def user(self, name: str, basedn: LDAPObject | str | None = "ou=users", rdn_attr: str | None = "cn") -> LDAPUser:
         """

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -55,8 +55,8 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-
         self.domain: str = self.host.domain
+
         """
         Samba domain name.
         """
@@ -69,6 +69,16 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
         self._password_policy: SambaPasswordPolicy = SambaPasswordPolicy(self)
         """
         Samba password policy.
+        """
+
+        self.name: str = "ad"
+        """
+        Provider name, samba is an "ad" alternative.
+        """
+
+        self.server: str = self.host.hostname
+        """
+        Generic server name.
         """
 
         self.automount: SambaAutomount = SambaAutomount(self)
@@ -158,6 +168,12 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
         Return fully qualified name in form name@domain.
         """
         return f"{name}@{self.domain}"
+
+    def dn(self, name: str) -> str:
+        """
+        Returns distinguished name in form of cn=name,naming_context.
+        """
+        return f"cn={name},{self.naming_context}"
 
     def user(self, name: str) -> SambaUser:
         """


### PR DESCRIPTION
* provider.name
* provider.naming_context
* provider.server
* provider.dn()
* provider.fqn()
