### PR TITLE
Revert "creating symlink for dsctl binary"

### DIFF
--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -146,14 +146,6 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
                 """
                 set -x
 
-                # Workaround https://issues.redhat.com/browse/RHEL-101926
-                if [ ! -f /usr/sbin/dsctl ]; then
-                    echo "/usr/sbin/dsctl is missing, creating symlink..."
-                    ln -s /usr/bin/dsctl /usr/sbin/dsctl
-                else
-                    echo "/usr/sbin/dsctl found, skipping..."
-                fi
-
                 function backup {
                     if [ -d "$1" ] || [ -f "$1" ]; then
                         cp --force --archive "$1" "$2"


### PR DESCRIPTION
Reverts SSSD/sssd-test-framework#196

This was a temporary fix. 