### PR TITLE
ci: run SSSD tests to avoid breaking it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,201 @@ jobs:
     - name: Run tests
       run: |
         tox --skip-env '${{ steps.skipenv.outputs.skipenv }}' --colored=yes --skip-pkg-install
+
+  system:
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+        - fedora-latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+
+    - name: Checkout sssd-test-framework repository
+      uses: actions/checkout@v5
+      with:
+        # Fetch the entire history of the repository and tags to determine
+        # correct framework version, as it is constructed from git describe
+        fetch-depth: 0
+        fetch-tags: true
+        path: sssd-test-framework
+
+    - name: Checkout sssd repository
+      uses: actions/checkout@v5
+      with:
+        repository: SSSD/sssd
+        path: sssd
+
+    - name: Setup containers
+      uses: SSSD/sssd-ci-containers/actions/setup@master
+      with:
+        path: sssd-ci-containers
+        tag: ${{ matrix.tag }}
+        override: |
+          services:
+            client:
+              image: ${REGISTRY}/ci-client-devel:${TAG}
+              shm_size: 4G
+              tmpfs:
+              - /dev/shm
+              volumes:
+              - ../sssd:/sssd:rw
+            ipa:
+              image: ${REGISTRY}/ci-ipa-devel:${TAG}
+              shm_size: 4G
+              tmpfs:
+              - /dev/shm
+              volumes:
+              - ../sssd:/sssd:rw
+
+    - name: Build SSSD on the client and IPA
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: build.log
+        working-directory: /sssd
+        where: |
+          client
+          ipa
+        script: |
+          #!/bin/bash
+          set -ex
+
+          ./contrib/ci/run --deps-only
+          autoreconf -if
+
+          mkdir -p /dev/shm/sssd
+          pushd /dev/shm/sssd
+          /sssd/configure --enable-silent-rules
+          make rpms
+
+    - name: Install SSSD on the client and IPA
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: install.log
+        user: root
+        where: |
+          client
+          ipa
+        script: |
+          #!/bin/bash
+          set -ex
+
+          dnf install -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
+          rm -fr /dev/shm/sssd
+
+          # We need to reenable sssd-kcm since it was disabled by removing sssd not not enabled again
+          systemctl enable --now sssd-kcm.socket
+
+    - name: Restart SSSD on IPA server
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        user: root
+        where: ipa
+        script: |
+          #!/bin/bash
+          set -ex
+
+          systemctl restart sssd || systemctl status sssd
+
+    - name: Patch the SSH configuration
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        user: root
+        script: |
+          #!/bin/bash
+          test -x /usr/bin/sss_ssh_knownhosts && \
+              sed -e 's/GlobalKnownHostsFile/#GlobalKnownHostsFile/' \
+                  -e 's/ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p %p %h/KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts %H/' \
+                  -i /etc/ssh/ssh_config.d/04-ipa.conf
+
+    - name: Install system tests dependencies
+      shell: bash
+      working-directory: ./sssd/src/tests/system
+      run: |
+        set -ex
+
+        sudo apt-get update
+
+        # Install dependencies for python-ldap
+        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev libssh-dev
+
+        # Virtualenv
+        pip3 install virtualenv
+        python3 -m venv .venv
+        source .venv/bin/activate
+
+        # Install system tests requirements
+        pip3 install -r ./requirements.txt
+
+        # Install yq to parse yaml files
+        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        sudo chmod a+x /usr/local/bin/yq
+
+    - name: Install test framework
+      shell: bash
+      run: |
+        set -ex
+
+        source ./sssd/src/tests/system/.venv/bin/activate
+        pip3 install ./sssd-test-framework
+
+    - name: Remove ad from mhc.yaml
+      shell: bash
+      working-directory: ./sssd/src/tests/system
+      run: |
+        yq -i 'del(.domains[0].hosts.[] | select(.role == "ad"))' mhc.yaml
+
+    - name: Check polarion metadata
+      shell: bash
+      working-directory: ./sssd/src/tests/system
+      run: |
+        # Run pytest in collect only mode to quickly catch issues in Polarion metadata.
+        set -ex -o pipefail
+
+        mkdir -p $GITHUB_WORKSPACE/artifacts
+        source .venv/bin/activate
+        pytest \
+          --color=yes \
+          --mh-config=./mhc.yaml \
+          --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
+          --polarion-config=../polarion.yaml \
+          --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
+          --collect-only . |& tee $GITHUB_WORKSPACE/pytest-collect.log
+
+    - name: Run tests
+      shell: bash
+      working-directory: ./sssd/src/tests/system
+      run: |
+        set -ex -o pipefail
+
+        mkdir -p $GITHUB_WORKSPACE/artifacts
+        source .venv/bin/activate
+        pytest \
+          --durations=0 \
+          --color=yes \
+          --show-capture=no \
+          --mh-config=./mhc.yaml \
+          --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
+          --polarion-config=../polarion.yaml \
+          --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
+          --output-polarion-testrun=$GITHUB_WORKSPACE/artifacts/testrun.xml \
+          -vvv . |& tee $GITHUB_WORKSPACE/pytest.log
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: ignore
+        name: ${{ matrix.tag }}-system
+        path: |
+          sssd/ci-install-deps.log
+          artifacts
+          build.log
+          install.log
+          pytest.log
+          pytest-collect.log


### PR DESCRIPTION
Running only against one distribution is enough, since we are not
testing SSSD, just the framework.