### PR TITLE
Refactor entities to be subclasses of generic ones

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,4 @@ add_imports = "from __future__ import annotations"
 
 [tool.black]
 line-length = 119
+target-version = ["py311"]

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -6,9 +6,8 @@ import os
 import re
 import textwrap
 import uuid
-from abc import ABC
 from datetime import datetime
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
 from pytest_mh.cli import CLIBuilderArgs
 from pytest_mh.conn import ProcessResult
@@ -24,9 +23,40 @@ from ..misc import (
     seconds_to_timespan,
 )
 from .base import BaseObject, BaseWindowsRole, DeleteAttribute
-from .generic import GenericCertificateAuthority, GenericPasswordPolicy
+from .generic import (
+    GenericAutomount,
+    GenericAutomountKey,
+    GenericAutomountMap,
+    GenericCertificateAuthority,
+    GenericComputer,
+    GenericDNSServer,
+    GenericDNSZone,
+    GenericGPO,
+    GenericGroup,
+    GenericNetgroup,
+    GenericNetgroupMember,
+    GenericOrganizationalUnit,
+    GenericPasswordPolicy,
+    GenericSite,
+    GenericSudoRule,
+    GenericUser,
+    GroupMemberField,
+    ProtocolName,
+    SudoRuleCommandField,
+    SudoRuleHostField,
+    SudoRuleRunAsGroupField,
+    SudoRuleRunAsUserField,
+    SudoRuleUserField,
+)
 from .ldap import LDAPNetgroupMember
 from .nfs import NFSExport
+
+_ADSudoUserInput: TypeAlias = SudoRuleUserField | int | list[SudoRuleUserField | int] | DeleteAttribute | None
+_ADSudoRunAsGroupInput: TypeAlias = (
+    SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | DeleteAttribute | None
+)
+_ADSudoUserAtom: TypeAlias = str | int | GenericUser | GenericGroup | ProtocolName
+_ADSudoGroupAtom: TypeAlias = str | int | GenericGroup | ProtocolName
 
 __all__ = [
     "AD",
@@ -566,7 +596,7 @@ class ADObject(BaseObject[ADHost, AD]):
         self.command_group: str = command_group
         """Active Directory Powershell module command group."""
 
-        self.name: str = name
+        self._name: str = name
         """Object name."""
 
         self.rdn: str = rdn
@@ -590,6 +620,10 @@ class ADObject(BaseObject[ADHost, AD]):
         self.__sid: str | None = None
 
         self.__create_default_ou(basedn, self.default_ou)
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def __create_default_ou(self, basedn: ADObject | str | None, default_ou: str | None) -> None:
         """
@@ -718,15 +752,18 @@ class ADObject(BaseObject[ADHost, AD]):
         }
         self._exec("Remove", self.cli.args(args, quote_value=True))
 
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get AD object attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericUser` API compatibility.
+        :type opattrs: bool, optional
         :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :rtype: dict[str, list[str]] | None
         """
+        _ = opattrs
         cmd = self._exec("Get", self.cli.args(self._identity, quote_value=True), format_with="Format-List")
         return attrs_parse(cmd.stdout_lines, attrs)
 
@@ -735,20 +772,25 @@ class ADObject(BaseObject[ADHost, AD]):
         """
         Gets AD Object's SID.
 
-        :return: SID
-        :rtype: str
+        :return: SID, or None if not available.
+        :rtype: str | None
         """
         if self.__sid is None:
-            for i in self.get(["SID"]).values():
-                if len(i) == 1:
-                    self.__sid = i[0]
+            sid_attrs = self.get(["SID"])
+            if sid_attrs is not None:
+                for i in sid_attrs.values():
+                    if len(i) == 1:
+                        self.__sid = i[0]
 
         return self.__sid
 
 
-class ADOrganizationalUnit(ADObject):
+class ADOrganizationalUnit(ADObject, GenericOrganizationalUnit):
     """
     AD organizational unit management.
+
+    :class:`ADOrganizationalUnit` implements :class:`GenericOrganizationalUnit` for static
+    typing and provider-agnostic tests.
     """
 
     def __init__(self, role: AD, name: str, basedn: ADObject | str | None = None) -> None:
@@ -762,13 +804,19 @@ class ADOrganizationalUnit(ADObject):
         """
         super().__init__(role, "OrganizationalUnit", name, f"ou={name}", basedn)
 
-    def add(self) -> ADOrganizationalUnit:
+    def add(self, name: str | None = None) -> ADOrganizationalUnit:
         """
         Create new AD organizational unit.
 
+        Implements :meth:`GenericOrganizationalUnit.add`. The optional ``name`` argument
+        is accepted for API compatibility; the OU name is taken from :meth:`AD.ou`.
+
+        :param name: Unused; OU name is set when the object is created.
+        :type name: str | None
         :return: Self.
         :rtype: ADOrganizationalUnit
         """
+        _ = name
         attrs: CLIBuilderArgs = {
             "Name": (self.cli.option.VALUE, self.name),
             "Path": (self.cli.option.VALUE, self.path),
@@ -779,9 +827,11 @@ class ADOrganizationalUnit(ADObject):
         return self
 
 
-class ADSite(ADObject):
+class ADSite(ADObject, GenericSite):
     """
-    AD Sites management.
+    AD site management.
+
+    :class:`ADSite` implements :class:`GenericSite` for static typing and provider-agnostic tests.
     """
 
     def __init__(self, role: AD, name: str, basedn: ADObject | str | None = "cn=sites,cn=configuration") -> None:
@@ -799,6 +849,8 @@ class ADSite(ADObject):
         """
         Create new AD site.
 
+        Implements :meth:`GenericSite.add`.
+
         :return: Self.
         :rtype: ADSite
         """
@@ -811,9 +863,12 @@ class ADSite(ADObject):
         return self
 
 
-class ADComputer(ADObject):
+class ADComputer(ADObject, GenericComputer):
     """
     AD computer management.
+
+    :class:`ADComputer` implements :class:`GenericComputer` for static typing and
+    provider-agnostic tests.
     """
 
     def __init__(self, role: AD, name: str, basedn: ADObject | str | None = "cn=computers") -> None:
@@ -830,9 +885,11 @@ class ADComputer(ADObject):
     def move(self, target: str) -> ADComputer:
         """
         Move a computer object.
+
+        Implements :meth:`GenericComputer.move`.
+
         :param target: Target path.
         :type target: str
-
         :return: Self.
         :rtype: ADComputer
         """
@@ -848,9 +905,12 @@ class ADComputer(ADObject):
         return self
 
 
-class ADUser(ADObject):
+class ADUser(ADObject, GenericUser):
     """
     AD user management.
+
+    :class:`ADUser` implements :class:`GenericUser` for static typing and provider-agnostic tests.
+    AD-specific keyword arguments on :meth:`add` and :meth:`modify` are in addition to the generic API.
     """
 
     def __init__(self, role: AD, name: str, basedn: ADObject | str | None = "cn=users") -> None:
@@ -1011,18 +1071,17 @@ class ADUser(ADObject):
 
         return self
 
-    def reset(
-        self,
-        password: str = "Secret123",
-    ) -> ADUser:
+    def reset(self, password: str | None = "Secret123") -> ADUser:
         """
         Reset user password.
 
         :param password: Password, defaults to 'Secret123'
-        :type password: str, optional
+        :type password: str | None, optional
         :return: Self.
         :rtype: ADUser
         """
+        if password is None:
+            password = "Secret123"
         attrs: CLIBuilderArgs = {
             **self._identity,
             "Reset": (self.cli.option.SWITCH, True),
@@ -1034,15 +1093,17 @@ class ADUser(ADObject):
 
         return self
 
-    def expire(self, expiration: str = "19700101000000") -> ADUser:
+    def expire(self, expiration: str | None = "19700101000000") -> ADUser:
         """
         Set user password expiration date and time.
 
-        :param expiration: Date and time for user password expiration, defaults to 19700101000000Z
-        :type expiration: str, optional
+        :param expiration: Date and time for user password expiration, defaults to 19700101000000
+        :type expiration: str | None, optional
         :return: Self.
         :rtype: ADUser
         """
+        if expiration is None:
+            expiration = "19700101000000"
         expire = datetime.strptime(expiration, "%Y%m%d%H%M%S")
         expire_format = expire.strftime("%m/%d/%Y %H:%M:%S")
 
@@ -1087,7 +1148,7 @@ class ADUser(ADObject):
         :param passkey_mapping: Passkey mapping generated by ``sssctl passkey-register``
         :type passkey_mapping: str
         :return: Self.
-        :rtype: ADUser.
+        :rtype: ADUser
         """
         attrs: CLIBuilderArgs = {
             **self._identity,
@@ -1097,9 +1158,12 @@ class ADUser(ADObject):
         return self
 
 
-class ADGroup(ADObject):
+class ADGroup(ADObject, GenericGroup):
     """
     AD group management.
+
+    :class:`ADGroup` implements :class:`GenericGroup` for static typing and provider-agnostic tests.
+    AD-specific keyword arguments on :meth:`add` are in addition to the generic API.
     """
 
     def __init__(self, role: AD, name: str, basedn: ADObject | str | None = "cn=users") -> None:
@@ -1169,7 +1233,7 @@ class ADGroup(ADObject):
         :param description: Description, defaults to None
         :type description: str | DeleteAttribute | None, optional
         :return: Self.
-        :rtype: ADUser
+        :rtype: ADGroup
         """
         unix_attrs = {
             "gidNumber": gid,
@@ -1192,23 +1256,23 @@ class ADGroup(ADObject):
         self._modify(attrs)
         return self
 
-    def add_member(self, member: ADUser | ADGroup) -> ADGroup:
+    def add_member(self, member: GroupMemberField) -> ADGroup:
         """
         Add group member.
 
         :param member: User or group to add as a member.
-        :type member: ADUser | ADGroup
+        :type member: GroupMemberField
         :return: Self.
         :rtype: ADGroup
         """
         return self.add_members([member])
 
-    def add_members(self, members: list[ADUser | ADGroup]) -> ADGroup:
+    def add_members(self, members: list[GroupMemberField]) -> ADGroup:
         """
         Add multiple group members.
 
         :param members: List of users or groups to add as members.
-        :type members: list[ADUser | ADGroup]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: ADGroup
         """
@@ -1218,23 +1282,23 @@ class ADGroup(ADObject):
         """)
         return self
 
-    def remove_member(self, member: ADUser | ADGroup) -> ADGroup:
+    def remove_member(self, member: GroupMemberField) -> ADGroup:
         """
         Remove group member.
 
         :param member: User or group to remove from the group.
-        :type member: ADUser | ADGroup
+        :type member: GroupMemberField
         :return: Self.
         :rtype: ADGroup
         """
         return self.remove_members([member])
 
-    def remove_members(self, members: list[ADUser | ADGroup]) -> ADGroup:
+    def remove_members(self, members: list[GroupMemberField]) -> ADGroup:
         """
         Remove multiple group members.
 
         :param members: List of users or groups to remove from the group.
-        :type members: list[ADUser | ADGroup]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: ADGroup
         """
@@ -1244,13 +1308,24 @@ class ADGroup(ADObject):
         """)
         return self
 
-    def __get_members(self, members: list[ADUser | ADGroup]) -> str:
-        return ",".join([f'"{x.dn}"' for x in members])
+    def __member_dn(self, member: GroupMemberField) -> str:
+        if isinstance(member, ADObject):
+            return member.dn
+        if isinstance(member, str):
+            return member
+        return member.name
+
+    def __get_members(self, members: list[GroupMemberField]) -> str:
+        return ",".join([f'"{self.__member_dn(x)}"' for x in members])
 
 
-class ADNetgroup(ADObject):
+class ADNetgroup(ADObject, GenericNetgroup):
     """
     AD netgroup management.
+
+    :class:`ADNetgroup` implements :class:`GenericNetgroup` for static typing and
+    provider-agnostic tests. The optional ``domain`` argument on membership methods is
+    AD-specific and is not part of the generic API.
     """
 
     def __init__(self, role: AD, name: str, basedn: ADObject | str | None = "ou=netgroups") -> None:
@@ -1290,9 +1365,9 @@ class ADNetgroup(ADObject):
         self,
         *,
         host: str | None = None,
-        user: ADUser | str | None = None,
+        user: GenericUser | str | None = None,
         domain: str | None = None,
-        ng: ADNetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> ADNetgroup:
         """
         Add netgroup member.
@@ -1300,22 +1375,22 @@ class ADNetgroup(ADObject):
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: ADUser | str | None, optional
-        :param domain: Domain, defaults to None
+        :type user: GenericUser | str | None, optional
+        :param domain: Domain (AD NIS triple field), defaults to None
         :type domain: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: ADNetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         :return: Self.
         :rtype: ADNetgroup
         """
         return self.add_members([ADNetgroupMember(host=host, user=user, domain=domain, ng=ng)])
 
-    def add_members(self, members: list[ADNetgroupMember]) -> ADNetgroup:
+    def add_members(self, members: list[GenericNetgroupMember]) -> ADNetgroup:
         """
         Add multiple netgroup members.
 
-        :param members: Netgroup members.
-        :type members: list[ADNetgroupMember]
+        :param members: Netgroup members (use :class:`ADNetgroupMember` for AD triples with domain).
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: ADNetgroup
         """
@@ -1340,9 +1415,9 @@ class ADNetgroup(ADObject):
         self,
         *,
         host: str | None = None,
-        user: ADUser | str | None = None,
+        user: GenericUser | str | None = None,
         domain: str | None = None,
-        ng: ADNetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> ADNetgroup:
         """
         Remove netgroup member.
@@ -1350,24 +1425,24 @@ class ADNetgroup(ADObject):
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: ADUser | str | None, optional
-        :param domain: Domain, defaults to None
+        :type user: GenericUser | str | None, optional
+        :param domain: Domain (AD NIS triple field), defaults to None
         :type domain: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: ADNetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         :return: Self.
         :rtype: ADNetgroup
         """
         return self.remove_members([ADNetgroupMember(host=host, user=user, domain=domain, ng=ng)])
 
-    def remove_members(self, members: list[ADNetgroupMember]) -> ADNetgroup:
+    def remove_members(self, members: list[GenericNetgroupMember]) -> ADNetgroup:
         """
         Remove multiple netgroup members.
 
-        :param members: Netgroup members.
-        :type members: list[LDAPNetgroupMember]
+        :param members: Netgroup members (use :class:`ADNetgroupMember` for AD triples with domain).
+        :type members: list[GenericNetgroupMember]
         :return: Self.
-        :rtype: LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]
+        :rtype: ADNetgroup
         """
         triples, netgroups = self.__members(members)
 
@@ -1386,12 +1461,12 @@ class ADNetgroup(ADObject):
         self._modify(args)
         return self
 
-    def __members(self, members: list[ADNetgroupMember]) -> tuple[list[str], list[str]]:
+    def __members(self, members: list[GenericNetgroupMember]) -> tuple[list[str], list[str]]:
         """
-        Split members into triples and netgroups
+        Split members into triples and netgroups.
 
         :param members: Netgroup members.
-        :type members: list[LDAPNetgroupMember]
+        :type members: list[GenericNetgroupMember]
         :return: (triples, netgroups)
         :rtype: tuple[list[str], list[str]]
         """
@@ -1409,9 +1484,14 @@ class ADNetgroup(ADObject):
         return triples, netgroups
 
 
-class ADSudoRule(ADObject):
+class ADSudoRule(ADObject, GenericSudoRule):
     """
     AD sudo rule management.
+
+    :class:`ADSudoRule` implements :class:`GenericSudoRule` for static typing and
+    provider-agnostic tests. AD-specific ``int`` values (SID fragments as ``#N``),
+    ``notbefore`` / ``notafter``, and :class:`DeleteAttribute` on :meth:`modify` are
+    in addition to the generic API.
     """
 
     def __init__(
@@ -1433,12 +1513,12 @@ class ADSudoRule(ADObject):
     def add(
         self,
         *,
-        user: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup] | None = None,
-        host: str | list[str] | None = None,
-        command: str | list[str] | None = None,
+        user: SudoRuleUserField | int | list[SudoRuleUserField | int] | None = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup] | None = None,
-        runasgroup: int | str | ADGroup | list[int | str | ADGroup] | None = None,
+        runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | None = None,
+        runasgroup: SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | None = None,
         notbefore: str | list[str] | None = None,
         notafter: str | list[str] | None = None,
         order: int | list[int] | None = None,
@@ -1448,20 +1528,20 @@ class ADSudoRule(ADObject):
         Create new sudo rule.
 
         :param user: sudoUser attribute, defaults to None
-        :type user: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup], optional
+        :type user: SudoRuleUserField | int | list[SudoRuleUserField | int], optional
         :param host: sudoHost attribute, defaults to None
-        :type host: str | list[str], optional
+        :type host: SudoRuleHostField, optional
         :param command: sudoCommand attribute, defaults to None
-        :type command: str | list[str], optional
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None
-        :type runasuser: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup] | None, optional
+        :type runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | None, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
-        :type runasgroup: int | str | ADGroup | list[int | str | ADGroup] | None, optional
-        :param notbefore: sudoNotBefore attribute, defaults to None
+        :type runasgroup: SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | None, optional
+        :param notbefore: sudoNotBefore attribute (AD only), defaults to None
         :type notbefore: str | list[str] | None, optional
-        :param notafter: sudoNotAfter attribute, defaults to None
+        :param notafter: sudoNotAfter attribute (AD only), defaults to None
         :type notafter: str | list[str] | None, optional
         :param order: sudoOrder attribute, defaults to None
         :type order: int | list[int] | None, optional
@@ -1501,12 +1581,14 @@ class ADSudoRule(ADObject):
     def modify(
         self,
         *,
-        user: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup] | DeleteAttribute | None = None,
-        host: str | list[str] | DeleteAttribute | None = None,
-        command: str | list[str] | DeleteAttribute | None = None,
+        user: SudoRuleUserField | int | list[SudoRuleUserField | int] | DeleteAttribute | None = None,
+        host: SudoRuleHostField | DeleteAttribute | None = None,
+        command: SudoRuleCommandField | DeleteAttribute | None = None,
         option: str | list[str] | DeleteAttribute | None = None,
-        runasuser: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup] | DeleteAttribute | None = None,
-        runasgroup: int | str | ADGroup | list[int | str | ADGroup] | DeleteAttribute | None = None,
+        runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | DeleteAttribute | None = None,
+        runasgroup: (
+            SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | DeleteAttribute | None
+        ) = None,
         notbefore: str | list[str] | DeleteAttribute | None = None,
         notafter: str | list[str] | DeleteAttribute | None = None,
         order: int | list[int] | DeleteAttribute | None = None,
@@ -1527,7 +1609,7 @@ class ADSudoRule(ADObject):
         :type command: str | list[str] | DeleteAttribute | None, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | DeleteAttribute | None, optional
-        :param runasuser: sudoRunAsUsere attribute, defaults to None
+        :param runasuser: sudoRunAsUser attribute, defaults to None
         :type runasuser: int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup]
           | DeleteAttribute | None, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
@@ -1574,14 +1656,12 @@ class ADSudoRule(ADObject):
         self._modify(args)
         return self
 
-    def __sudo_user(
-        self, sudo_user: None | DeleteAttribute | int | str | ADUser | ADGroup | list[int | str | ADUser | ADGroup]
-    ) -> list[str] | DeleteAttribute | None:
-        def _get_value(value: int | str | ADUser | ADGroup) -> str:
-            if isinstance(value, ADUser):
+    def __sudo_user(self, sudo_user: _ADSudoUserInput) -> list[str] | DeleteAttribute | None:
+        def _get_value(value: _ADSudoUserAtom) -> str:
+            if isinstance(value, GenericUser):
                 return value.name
 
-            if isinstance(value, ADGroup):
+            if isinstance(value, GenericGroup):
                 return "%" + value.name
 
             if isinstance(value, str):
@@ -1589,6 +1669,10 @@ class ADSudoRule(ADObject):
 
             if isinstance(value, int):
                 return "#" + str(value)
+
+            name = getattr(value, "name", None)
+            if isinstance(name, str):
+                return name
 
             raise ValueError(f"Unsupported type: {type(value)}")
 
@@ -1599,19 +1683,17 @@ class ADSudoRule(ADObject):
             return sudo_user
 
         if not isinstance(sudo_user, list):
-            return [_get_value(sudo_user)]
+            return [_get_value(cast(_ADSudoUserAtom, sudo_user))]
 
         out = []
         for value in sudo_user:
-            out.append(_get_value(value))
+            out.append(_get_value(cast(_ADSudoUserAtom, value)))
 
         return out
 
-    def __sudo_group(
-        self, sudo_group: None | DeleteAttribute | int | str | ADGroup | list[int | str | ADGroup]
-    ) -> list[str] | DeleteAttribute | None:
-        def _get_value(value: int | str | ADGroup):
-            if isinstance(value, ADGroup):
+    def __sudo_group(self, sudo_group: _ADSudoRunAsGroupInput) -> list[str] | DeleteAttribute | None:
+        def _get_value(value: _ADSudoGroupAtom) -> str:
+            if isinstance(value, GenericGroup):
                 return value.name
 
             if isinstance(value, str):
@@ -1619,6 +1701,10 @@ class ADSudoRule(ADObject):
 
             if isinstance(value, int):
                 return "#" + str(value)
+
+            name = getattr(value, "name", None)
+            if isinstance(name, str):
+                return name
 
             raise ValueError(f"Unsupported type: {type(value)}")
 
@@ -1629,18 +1715,22 @@ class ADSudoRule(ADObject):
             return sudo_group
 
         if not isinstance(sudo_group, list):
-            return [_get_value(sudo_group)]
+            return [_get_value(cast(_ADSudoGroupAtom, sudo_group))]
 
         out = []
         for value in sudo_group:
-            out.append(_get_value(value))
+            out.append(_get_value(cast(_ADSudoGroupAtom, value)))
 
         return out
 
 
-class ADAutomount(object):
+class ADAutomount(GenericAutomount):
     """
     AD automount management.
+
+    :class:`ADAutomount` implements :class:`GenericAutomount` for static typing and
+    provider-agnostic tests. The optional ``basedn`` argument on :meth:`map` is
+    AD-specific and is not part of the generic API.
     """
 
     def __init__(self, role: AD) -> None:
@@ -1654,6 +1744,9 @@ class ADAutomount(object):
         """
         Get automount map object.
 
+        Implements :meth:`GenericAutomount.map`; ``basedn`` selects the LDAP container
+        for the map (defaults to ``ou=autofs``).
+
         :param name: Automount map name.
         :type name: str
         :param basedn: Base dn, defaults to ``ou=autofs``
@@ -1663,23 +1756,30 @@ class ADAutomount(object):
         """
         return ADAutomountMap(self.__role, name, basedn)
 
-    def key(self, name: str, map: ADAutomountMap) -> ADAutomountKey:
+    def key(self, name: str, map: GenericAutomountMap) -> ADAutomountKey:
         """
         Get automount key object.
+
+        Implements :meth:`GenericAutomount.key`.
 
         :param name: Automount key name.
         :type name: str
         :param map: Automount map that is a parent to this key.
-        :type map: ADAutomountMap
+        :type map: GenericAutomountMap
         :return: New automount key object.
         :rtype: ADAutomountKey
         """
+        if not isinstance(map, ADAutomountMap):
+            raise TypeError("AD automount keys require an ADAutomountMap parent map.")
         return ADAutomountKey(self.__role, name, map)
 
 
-class ADAutomountMap(ADObject):
+class ADAutomountMap(ADObject, GenericAutomountMap):
     """
     AD automount map management.
+
+    :class:`ADAutomountMap` implements :class:`GenericAutomountMap` for static typing
+    and provider-agnostic tests.
     """
 
     def __init__(
@@ -1735,9 +1835,12 @@ class ADAutomountMap(ADObject):
         return ADAutomountKey(self.role, name, self)
 
 
-class ADAutomountKey(ADObject):
+class ADAutomountKey(ADObject, GenericAutomountKey):
     """
     AD automount key management.
+
+    :class:`ADAutomountKey` implements :class:`GenericAutomountKey` for static typing
+    and provider-agnostic tests.
     """
 
     def __init__(
@@ -1758,12 +1861,12 @@ class ADAutomountKey(ADObject):
         self.map: ADAutomountMap = map
         self.info: str | None = None
 
-    def add(self, *, info: str | NFSExport | ADAutomountMap) -> ADAutomountKey:
+    def add(self, *, info: str | NFSExport | GenericAutomountMap) -> ADAutomountKey:
         """
         Create new AD automount key.
 
         :param info: Automount information.
-        :type info: str | NFSExport | ADAutomountMap
+        :type info: str | NFSExport | GenericAutomountMap
         :return: Self.
         :rtype: ADAutomountKey
         """
@@ -1793,7 +1896,7 @@ class ADAutomountKey(ADObject):
     def modify(
         self,
         *,
-        info: str | NFSExport | ADAutomountMap | DeleteAttribute | None = None,
+        info: str | NFSExport | GenericAutomountMap | DeleteAttribute | None = None,
     ) -> ADAutomountKey:
         """
         Modify existing AD automount key.
@@ -1802,7 +1905,7 @@ class ADAutomountKey(ADObject):
         attribute by setting the value to :attr:`Delete`.
 
         :param info: Automount information, defaults to ``None``
-        :type info:  str | NFSExport | ADAutomountMap | DeleteAttribute | None
+        :type info: str | NFSExport | GenericAutomountMap | DeleteAttribute | None
         :return: Self.
         :rtype: ADAutomountKey
         """
@@ -1851,32 +1954,34 @@ class ADAutomountKey(ADObject):
         return self.dump()
 
     def __get_info(
-        self, info: str | NFSExport | ADAutomountMap | DeleteAttribute | None
+        self, info: str | NFSExport | GenericAutomountMap | DeleteAttribute | None
     ) -> str | DeleteAttribute | None:
         if isinstance(info, NFSExport):
             return info.get()
 
-        if isinstance(info, ADAutomountMap):
+        if isinstance(info, GenericAutomountMap):
             return info.name
 
         return info
 
 
-class GPO(BaseObject[ADHost, AD]):
+class GPO(GenericGPO):
     """
     Group policy object management.
+
+    :class:`GPO` implements :class:`GenericGPO` for static typing and provider-agnostic tests.
     """
 
     def __init__(self, role: AD, name: str) -> None:
         """
-        :param role: AD host object.
-        :type role:  ADHost
-        :param name: GPO name, defaults to 'Domain Test Policy'
-        :type name: str, optional
+        :param role: AD role object.
+        :type role: AD
+        :param name: GPO display name.
+        :type name: str
         """
         super().__init__(role)
 
-        self.name: str = name
+        self._name: str = name
         """Group policy display name."""
 
         self.target: str | None = None
@@ -1890,6 +1995,15 @@ class GPO(BaseObject[ADHost, AD]):
 
         self.cn = self.get("CN")
         """Group policy cn."""
+
+    @property
+    def name(self) -> str:
+        """
+        GPO display name.
+
+        Implements :attr:`GenericGPO.name`.
+        """
+        return self._name
 
     def get(self, key: str) -> str | None:
         """
@@ -2008,16 +2122,13 @@ class GPO(BaseObject[ADHost, AD]):
 
         return self
 
-    def unlink(self) -> GPO:
+    def unlink(self) -> None:
         """
         Unlink the group policy from the target.
 
-        :return: Group policy object
-        :rtype: GPO
+        Implements :meth:`GenericGPO.unlink`.
         """
         self.role.host.conn.run(f'Remove-GPLink -Guid "{self.cn}" -Target "{self.target}"')
-
-        return self
 
     def permissions(self, target: str, permission_level: str, target_type: str | None = "Group") -> GPO:
         """
@@ -2148,13 +2259,17 @@ class GPO(BaseObject[ADHost, AD]):
 
 class ADPasswordPolicy(GenericPasswordPolicy):
     """
-    Password policy management.
+    AD domain password policy management.
+
+    :class:`ADPasswordPolicy` implements :class:`GenericPasswordPolicy` for static typing
+    and provider-agnostic tests. Settings apply to the domain default password policy via
+    ``Set-ADDefaultDomainPasswordPolicy``.
     """
 
-    def __init__(self, role: AD):
+    def __init__(self, role: AD) -> None:
         """
-        :param role: AD host object.
-        :type role: ADHost
+        :param role: AD role object.
+        :type role: AD
         """
         super().__init__(role)
 
@@ -2170,9 +2285,11 @@ class ADPasswordPolicy(GenericPasswordPolicy):
         """
         Enable or disable password complexity.
 
+        Implements :meth:`GenericPasswordPolicy.complexity`.
+
         :param enable: Enable or disable password complexity.
         :type enable: bool
-        :return: ADPasswordPolicy object.
+        :return: Self.
         :rtype: ADPasswordPolicy
         """
         args: CLIBuilderArgs = {
@@ -2187,11 +2304,13 @@ class ADPasswordPolicy(GenericPasswordPolicy):
         """
         Set lockout duration and login attempts.
 
+        Implements :meth:`GenericPasswordPolicy.lockout`.
+
         :param duration: Duration of lockout in seconds.
         :type duration: int
         :param attempts: Number of login attempts.
         :type attempts: int
-        :return: ADPasswordPolicy object.
+        :return: Self.
         :rtype: ADPasswordPolicy
         """
         args: CLIBuilderArgs = {
@@ -2204,11 +2323,18 @@ class ADPasswordPolicy(GenericPasswordPolicy):
         return self
 
 
-class ADDNSServer(BaseObject[ADHost, AD]):
-    def __init__(self, role: AD):
+class ADDNSServer(GenericDNSServer):
+    """
+    AD DNS server management.
+
+    :class:`ADDNSServer` implements :class:`GenericDNSServer` for static typing and
+    provider-agnostic tests.
+    """
+
+    def __init__(self, role: AD) -> None:
         """
-        :param role: AD host object.
-        :type role: ADHost
+        :param role: AD role object.
+        :type role: AD
         """
         super().__init__(role)
 
@@ -2220,20 +2346,22 @@ class ADDNSServer(BaseObject[ADHost, AD]):
 
     def zone(self, name: str) -> ADDNSZone:
         """
-        Get ADDNsServerZone object.
+        Get DNS zone object.
+
+        Implements :meth:`GenericDNSServer.zone`.
 
         :param name: Zone name.
         :type name: str
-        :return: ADDNSServerZone object.
+        :return: DNS zone object.
         :rtype: ADDNSZone
         """
         return ADDNSZone(self.role, name)
 
-    def get_forwarders(self) -> list[str] | None:
+    def get_forwarders(self) -> list[str]:
         """
         Get DNS global forwarders.
 
-        :return: DNS global forwarders.
+        :return: List of forwarder IP addresses (empty if none are configured).
         :rtype: list[str]
         """
         forwarders = self.host.conn.run("Get-DnsServerForwarder").stdout_lines
@@ -2245,18 +2373,15 @@ class ADDNSServer(BaseObject[ADHost, AD]):
                     ip_addresses = [s.strip() for s in ip_addresses]
                     ip_addresses = [r.replace("...", "") for r in ip_addresses]
                     return ip_addresses[0].strip("{}").split(",")
-                else:
-                    return None
-            else:
-                return None
+        return []
 
     def add_forwarder(self, ip_address: str) -> ADDNSServer:
         """
         Add a DNS server forwarder.
 
-        :param ip_address: IP address.,
+        :param ip_address: IP address.
         :type ip_address: str
-        :return:  Self.
+        :return: Self.
         :rtype: ADDNSServer
         """
         self.host.conn.run(f"Add-DnsServerForwarder -IPAddress {ip_address}")
@@ -2299,15 +2424,18 @@ class ADDNSServer(BaseObject[ADHost, AD]):
         return result
 
 
-class ADDNSZone(ADDNSServer, ABC):
+class ADDNSZone(ADDNSServer, GenericDNSZone):
     """
-    DNS zone management.
+    AD DNS zone management.
+
+    :class:`ADDNSZone` implements :class:`GenericDNSZone` for static typing and
+    provider-agnostic tests.
     """
 
-    def __init__(self, role: AD, name: str):
+    def __init__(self, role: AD, name: str) -> None:
         """
-        :param name: DNS zone name.
-        :type name: str
+        :param role: AD role object.
+        :type role: AD
         :param name: DNS zone name.
         :type name: str
         """
@@ -2320,8 +2448,8 @@ class ADDNSZone(ADDNSServer, ABC):
         """
         Create new zone.
 
-        :return: ADDNSServer object.
-        :rtype: ADDNSServer
+        :return: Self.
+        :rtype: ADDNSZone
         """
         self.host.conn.run(f"Add-DnsServerPrimaryZone -Name {self.zone_name} -ReplicationScope Forest -Passthru")
         return self
@@ -2417,9 +2545,11 @@ class ADCertificateAuthority(GenericCertificateAuthority):
     """
     AD Certificate Authority server management.
 
-    This class provides certificate operations for Active Directory Certificate
-    Authority, including requesting, revoking, placing/removing certificate holds,
-    and retrieving certificate information via certreq and certutil commands.
+    :class:`ADCertificateAuthority` implements :class:`GenericCertificateAuthority` for
+    static typing and provider-agnostic tests. It requests, revokes, places/removes
+    certificate holds, and retrieves certificate information via ``certreq`` and
+    ``certutil``. :meth:`request` requires AD-specific ``template`` and ``subject``
+    arguments; :meth:`request_basic` is an additional AD helper without enrollment agent.
     """
 
     def __init__(self, host: ADHost) -> None:
@@ -2598,12 +2728,14 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         self,
         template: str,
         subject: str,
+        **kwargs: Any,
     ) -> tuple[str, str, str]:
         """
         Request a smartcard certificate using Enrollment Agent.
 
-        Uses "Enroll On Behalf Of" functionality to issue certificates
-        with the correct subject for the target user.
+        Implements :meth:`GenericCertificateAuthority.request`. Uses "Enroll On Behalf Of"
+        functionality to issue certificates with the correct subject for the target user.
+        Extra ``**kwargs`` are ignored.
 
         :param template: Smartcard certificate template name (e.g., "SmartcardLogon").
         :type template: str
@@ -2612,6 +2744,7 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         :return: A tuple of (certificate_path, key_path, csr_path).
         :rtype: tuple[str, str, str]
         """
+        del kwargs
         base_dn = ",".join(f"dc={part}" for part in self.host.domain.split(".") if part)
         user_dn = subject
         if base_dn.lower() not in subject.lower():
@@ -2660,8 +2793,7 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         self.export_pfx(cert_path, pfx_path)
 
         self.host.conn.run(
-            f'"Secret123" | & openssl pkcs12 -in {pfx_path} -nocerts -nodes'
-            f" -out {extracted_key_path} -passin stdin"
+            f'"Secret123" | & openssl pkcs12 -in {pfx_path} -nocerts -nodes -out {extracted_key_path} -passin stdin'
         )
 
         self.host.conn.run(f"openssl rsa -in {extracted_key_path} -out {key_path}")
@@ -2697,6 +2829,8 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         """
         Revoke a certificate in AD CA.
 
+        Implements :meth:`GenericCertificateAuthority.revoke`.
+
         Valid revocation reasons:
 
         - ``unspecified`` (default)
@@ -2724,6 +2858,8 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         """
         Place a certificate on hold.
 
+        Implements :meth:`GenericCertificateAuthority.revoke_hold`.
+
         :param cert_path: Path to the certificate file.
         :type cert_path: str
         """
@@ -2732,6 +2868,8 @@ class ADCertificateAuthority(GenericCertificateAuthority):
     def revoke_hold_remove(self, cert_path: str) -> None:
         """
         Remove hold from a certificate.
+
+        Implements :meth:`GenericCertificateAuthority.revoke_hold_remove`.
 
         :param cert_path: Path to the certificate file.
         :type cert_path: str
@@ -2743,6 +2881,8 @@ class ADCertificateAuthority(GenericCertificateAuthority):
     def get(self, cert_path: str) -> dict[str, list[str]]:
         """
         Retrieve certificate details from AD CA.
+
+        Implements :meth:`GenericCertificateAuthority.get`.
 
         :param cert_path: Path to the certificate file.
         :type cert_path: str

--- a/sssd_test_framework/roles/client.py
+++ b/sssd_test_framework/roles/client.py
@@ -86,7 +86,7 @@ class Client(BaseLinuxRole[ClientHost]):
         Methods for testing automount.
         """
 
-        self.local: LocalUsersUtils = LocalUsersUtils(self.host, self.fs)
+        self.local: LocalUsersUtils = LocalUsersUtils(self.host, self.fs, client=self)
         """
         Managing local users and groups.
         """

--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -25,6 +25,11 @@ __all__ = [
     "GenericNetgroup",
     "GenericNetgroupMember",
     "GenericSudoRule",
+    "SudoRuleUserField",
+    "SudoRuleHostField",
+    "SudoRuleCommandField",
+    "SudoRuleRunAsUserField",
+    "SudoRuleRunAsGroupField",
     "GenericAutomount",
     "GenericAutomountMap",
     "GenericAutomountKey",
@@ -32,6 +37,7 @@ __all__ = [
     "GenericDNSServer",
     "GenericDNSZone",
     "GenericCertificateAuthority",
+    "GroupMemberField",
 ]
 
 
@@ -640,7 +646,7 @@ class GenericUser(ABC, BaseObject):
         :param password: Password, defaults to 'Secret123'
         :type password: str, optional
         :return: Self.
-        :rtype: IPAUser
+        :rtype: GenericUser
         """
         pass
 
@@ -650,9 +656,9 @@ class GenericUser(ABC, BaseObject):
         Set user password expiration date and time.
 
         :param expiration: Date and time for user password expiration, defaults to 19700101000000
-        :type expirataion: str, optional
+        :type expiration: str, optional
         :return: Self.
-        :rtype: IPAUser
+        :rtype: GenericUser
         """
         pass
 
@@ -677,14 +683,16 @@ class GenericUser(ABC, BaseObject):
         pass
 
     @abstractmethod
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get user attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
-        :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :param opattrs: If True, include operational attributes (LDAP only), defaults to False
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key, or None if not found.
+        :rtype: dict[str, list[str]] | None
         """
         pass
 
@@ -776,64 +784,70 @@ class GenericGroup(ABC, BaseObject):
         pass
 
     @abstractmethod
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get group attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
-        :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :param opattrs: If True, include operational attributes (LDAP only), defaults to False
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key, or None if not found.
+        :rtype: dict[str, list[str]] | None
         """
         pass
 
     @abstractmethod
-    def add_member(self, member: GenericUser | GenericGroup) -> GenericGroup:
+    def add_member(self, member: GroupMemberField) -> GenericGroup:
         """
         Add group member.
 
-        :param member: User or group to add as a member.
-        :type member: GenericUser | GenericGroup
+        :param member: User, group, or member name / external principal string.
+        :type member: GroupMemberField
         :return: Self.
         :rtype: GenericGroup
         """
         pass
 
     @abstractmethod
-    def add_members(self, members: list[GenericUser | GenericGroup]) -> GenericGroup:
+    def add_members(self, members: list[GroupMemberField]) -> GenericGroup:
         """
         Add multiple group members.
 
-        :param members: List of users or groups to add as members.
-        :type members: list[GenericUser | GenericGroup]
+        :param members: List of users, groups, or member name strings.
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: GenericGroup
         """
         pass
 
     @abstractmethod
-    def remove_member(self, member: GenericUser | GenericGroup) -> GenericGroup:
+    def remove_member(self, member: GroupMemberField) -> GenericGroup:
         """
         Remove group member.
 
-        :param member: User or group to remove from the group.
-        :type member: GenericUser | GenericGroup
+        :param member: User, group, or member name / external principal string.
+        :type member: GroupMemberField
         :return: Self.
         :rtype: GenericGroup
         """
         pass
 
     @abstractmethod
-    def remove_members(self, members: list[GenericUser | GenericGroup]) -> GenericGroup:
+    def remove_members(self, members: list[GroupMemberField]) -> GenericGroup:
         """
         Remove multiple group members.
 
-        :param members: List of users or groups to remove from the group.
-        :type members: list[GenericUser | GenericGroup]
+        :param members: List of users, groups, or member name strings.
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: GenericGroup
         """
         pass
+
+
+GroupMemberField = GenericUser | GenericGroup | str
+"""Group member: user, nested group, or string (name / external member / RDN fragment)."""
 
 
 class GenericComputer(ABC, BaseObject):
@@ -904,7 +918,7 @@ class GenericNetgroup(ABC, BaseObject):
         Create a new netgroup.
 
         :return: Self.
-        :rtype: GenericNetroup
+        :rtype: GenericNetgroup
         """
         pass
 
@@ -916,14 +930,16 @@ class GenericNetgroup(ABC, BaseObject):
         pass
 
     @abstractmethod
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get netgroup attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
-        :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :param opattrs: If True, include operational attributes (LDAP only), defaults to False
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key, or None if not found.
+        :rtype: dict[str, list[str]] | None
         """
         pass
 
@@ -970,7 +986,7 @@ class GenericNetgroup(ABC, BaseObject):
         ng: GenericNetgroup | str | None = None,
     ) -> GenericNetgroup:
         """
-        Remove group member.
+        Remove netgroup member.
 
         :param host: Host, defaults to None
         :type host: str | None, optional
@@ -979,19 +995,19 @@ class GenericNetgroup(ABC, BaseObject):
         :param ng: Netgroup, defaults to None
         :type ng: GenericNetgroup | str | None, optional
         :return: Self.
-        :rtype: GenericNetroup
+        :rtype: GenericNetgroup
         """
         pass
 
     @abstractmethod
     def remove_members(self, members: list[GenericNetgroupMember]) -> GenericNetgroup:
         """
-        Remove multiple group members.
+        Remove multiple netgroup members.
 
-        :param members: List of netgroup members to add.
+        :param members: List of netgroup members to remove.
         :type members: list[GenericNetgroupMember]
         :return: Self.
-        :rtype: GenericNetroup
+        :rtype: GenericNetgroup
         """
         pass
 
@@ -1009,15 +1025,19 @@ class GenericNetgroupMember(object):
     """
 
     def __init__(
-        self, *, host: str | None = None, user: ProtocolName | str | None = None, ng: ProtocolName | str | None = None
+        self,
+        *,
+        host: str | None = None,
+        user: GenericUser | ProtocolName | str | None = None,
+        ng: GenericNetgroup | ProtocolName | str | None = None,
     ) -> None:
         """
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: ProtocolName | str | None, optional
+        :type user: GenericUser | ProtocolName | str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: ProtocolName | str | None, optional
+        :type ng: GenericNetgroup | ProtocolName | str | None, optional
         """
         self.host: str | None = host
         """Member host."""
@@ -1028,7 +1048,10 @@ class GenericNetgroupMember(object):
         self.netgroup: str | None = self._get_name(ng)
         """Member netgroup."""
 
-    def _get_name(self, item: ProtocolName | str | None = None) -> str | None:
+    def _get_name(
+        self,
+        item: GenericUser | GenericNetgroup | GenericGroup | ProtocolName | str | None = None,
+    ) -> str | None:
         if item is None:
             return None
 
@@ -1036,6 +1059,34 @@ class GenericNetgroupMember(object):
             return item.name
 
         return item
+
+    def triple(self) -> str | None:
+        """
+        NIS netgroup triple string ``(host,user,)``.
+
+        :class:`LDAPNetgroupMember` overrides this when a ``domain`` field is set.
+        :class:`LocalNetgroupMember` uses :meth:`LocalNetgroupMember.to_member_string` instead.
+
+        :return: Triple string, or None if the member is only a nested netgroup.
+        :rtype: str | None
+        """
+        if self.host is None and self.user is None:
+            return None
+
+        host = self.host if self.host is not None else "-"
+        user = self.user if self.user is not None else "-"
+        return f"({host},{user},)"
+
+
+SudoRuleUserField = (
+    str | GenericUser | GenericGroup | ProtocolName | list[str | GenericUser | GenericGroup | ProtocolName] | None
+)
+SudoRuleHostField = str | ProtocolName | list[str | ProtocolName] | None
+SudoRuleCommandField = str | ProtocolName | list[str | ProtocolName] | None
+SudoRuleRunAsUserField = (
+    str | GenericUser | GenericGroup | ProtocolName | list[str | GenericUser | GenericGroup | ProtocolName] | None
+)
+SudoRuleRunAsGroupField = str | GenericGroup | ProtocolName | list[str | GenericGroup | ProtocolName] | None
 
 
 class GenericSudoRule(ABC, BaseObject):
@@ -1055,12 +1106,12 @@ class GenericSudoRule(ABC, BaseObject):
     def add(
         self,
         *,
-        user: str | GenericUser | GenericGroup | list[str | GenericUser | GenericGroup] | None = None,
-        host: str | list[str] | None = None,
-        command: str | list[str] | None = None,
+        user: SudoRuleUserField = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: str | GenericUser | GenericGroup | list[str | GenericUser | GenericGroup] | None = None,
-        runasgroup: str | GenericGroup | list[str | GenericGroup] | None = None,
+        runasuser: SudoRuleRunAsUserField = None,
+        runasgroup: SudoRuleRunAsGroupField = None,
         order: int | None = None,
         nopasswd: bool | None = None,
     ) -> GenericSudoRule:
@@ -1068,22 +1119,22 @@ class GenericSudoRule(ABC, BaseObject):
         Create new sudo rule.
 
         :param user: sudoUser attribute, defaults to None
-        :type user: str | GenericUser | GenericGroup | list[str  |  GenericUser  |  GenericGroup] | None, optional
+        :type user: SudoRuleUserField, optional
         :param host: sudoHost attribute, defaults to None
-        :type host: str | list[str] | None, optional
+        :type host: SudoRuleHostField, optional
         :param command: sudoCommand attribute, defaults to None
-        :type command: str | list[str] | None, optional
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None
-        :type runasuser: str | GenericUser | GenericGroup | list[str  |  GenericUser  |  GenericGroup] | None, optional
+        :type runasuser: SudoRuleRunAsUserField, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
-        :type runasgroup: str | GenericGroup | list[str  |  GenericGroup] | None, optional
+        :type runasgroup: SudoRuleRunAsGroupField, optional
         :param order: sudoOrder attribute, defaults to None
         :type order: int | None, optional
         :param nopasswd: If true, no authentication is required (NOPASSWD), defaults to None (no change)
         :type nopasswd: bool | None, optional
-        :return: _description_
+        :return: Self.
         :rtype: GenericSudoRule
         """
         pass
@@ -1092,35 +1143,35 @@ class GenericSudoRule(ABC, BaseObject):
     def modify(
         self,
         *,
-        user: str | GenericUser | GenericGroup | list[str | GenericUser | GenericGroup] | None = None,
-        host: str | list[str] | None = None,
-        command: str | list[str] | None = None,
+        user: SudoRuleUserField = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: str | GenericUser | GenericGroup | list[str | GenericUser | GenericGroup] | None = None,
-        runasgroup: str | GenericGroup | list[str | GenericGroup] | None = None,
+        runasuser: SudoRuleRunAsUserField = None,
+        runasgroup: SudoRuleRunAsGroupField = None,
         order: int | None = None,
         nopasswd: bool | None = None,
     ) -> GenericSudoRule:
         """
-        Create new sudo rule.
+        Modify existing sudo rule.
 
         :param user: sudoUser attribute, defaults to None
-        :type user: str | GenericUser | GenericGroup | list[str  |  GenericUser  |  GenericGroup] | None, optional
+        :type user: SudoRuleUserField, optional
         :param host: sudoHost attribute, defaults to None
-        :type host: str | list[str] | None, optional
+        :type host: SudoRuleHostField, optional
         :param command: sudoCommand attribute, defaults to None
-        :type command: str | list[str] | None, optional
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None
-        :type runasuser: str | GenericUser | GenericGroup | list[str  |  GenericUser  |  GenericGroup] | None, optional
+        :type runasuser: SudoRuleRunAsUserField, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
-        :type runasgroup: str | GenericGroup | list[str  |  GenericGroup] | None, optional
+        :type runasgroup: SudoRuleRunAsGroupField, optional
         :param order: sudoOrder attribute, defaults to None
         :type order: int | None, optional
         :param nopasswd: If true, no authentication is required (NOPASSWD), defaults to None (no change)
         :type nopasswd: bool | None, optional
-        :return: _description_
+        :return: Self.
         :rtype: GenericSudoRule
         """
         pass
@@ -1133,14 +1184,16 @@ class GenericSudoRule(ABC, BaseObject):
         pass
 
     @abstractmethod
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get sudo rule attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
-        :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :param opattrs: If True, include operational attributes (LDAP only), defaults to False
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key, or None if not found.
+        :rtype: dict[str, list[str]] | None
         """
         pass
 
@@ -1215,19 +1268,21 @@ class GenericAutomountMap(ABC, BaseObject):
     @abstractmethod
     def delete(self) -> None:
         """
-        Delete the automout map.
+        Delete the automount map.
         """
         pass
 
     @abstractmethod
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get automount map attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
-        :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :param opattrs: If True, include operational attributes (LDAP only), defaults to False
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key, or None if not found.
+        :rtype: dict[str, list[str]] | None
         """
         pass
 
@@ -1241,7 +1296,7 @@ class GenericAutomountKey(ABC, BaseObject):
     @abstractmethod
     def name(self):
         """
-        Automoutn key name.
+        Automount key name.
         """
         pass
 
@@ -1281,14 +1336,16 @@ class GenericAutomountKey(ABC, BaseObject):
         pass
 
     @abstractmethod
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get automount key attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
-        :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :param opattrs: If True, include operational attributes (LDAP only), defaults to False
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key, or None if not found.
+        :rtype: dict[str, list[str]] | None
         """
         pass
 
@@ -1520,8 +1577,8 @@ class GenericDNSZone(GenericDNSServer):
         """
         Create DNS zone.
 
-        :return: GenericDNSServer object.
-        :rtype: GenericDNSServer
+        :return: Self.
+        :rtype: GenericDNSZone
         """
         pass
 
@@ -1571,7 +1628,6 @@ class GenericDNSZone(GenericDNSServer):
 
 
 class GenericCertificateAuthority(ABC):
-
     @abstractmethod
     def request(self, *args, **kwargs) -> tuple[str, str, str]:
         """

--- a/sssd_test_framework/roles/ipa.py
+++ b/sssd_test_framework/roles/ipa.py
@@ -32,7 +32,26 @@ from ..roles.client import Client
 from ..utils.sssctl import SSSCTLUtils
 from ..utils.sssd import SSSDUtils
 from .base import BaseLinuxRole, BaseObject
-from .generic import GenericCertificateAuthority, GenericNetgroupMember, GenericPasswordPolicy
+from .generic import (
+    GenericAutomount,
+    GenericAutomountKey,
+    GenericAutomountMap,
+    GenericCertificateAuthority,
+    GenericDNSServer,
+    GenericDNSZone,
+    GenericGroup,
+    GenericNetgroup,
+    GenericNetgroupMember,
+    GenericPasswordPolicy,
+    GenericSudoRule,
+    GenericUser,
+    GroupMemberField,
+    SudoRuleCommandField,
+    SudoRuleHostField,
+    SudoRuleRunAsGroupField,
+    SudoRuleRunAsUserField,
+    SudoRuleUserField,
+)
 from .nfs import NFSExport
 
 __all__ = [
@@ -765,8 +784,12 @@ class IPAObject(BaseObject[IPAHost, IPA]):
         self.command_group: str = command_group
         """IPA cli command group."""
 
-        self.name: str = name
+        self._name: str = name
         """Object name."""
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def _exec(
         self, op: str, args: list[str] | None = None, ipaargs: list[str] | None = None, **kwargs
@@ -827,15 +850,18 @@ class IPAObject(BaseObject[IPAHost, IPA]):
         """
         self._exec("del")
 
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]] | None:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get IPA object attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for generic entity API compatibility.
+        :type opattrs: bool, optional
         :return: Dictionary with attribute name as a key or None if no such attribute is found.
         :rtype: dict[str, list[str]] | None
         """
+        _ = opattrs
         cmd = self._exec("show", ["--all", "--raw"], raise_on_error=False)
 
         # ipa output starts with space
@@ -848,9 +874,12 @@ class IPAObject(BaseObject[IPAHost, IPA]):
         return attrs_parse(lines[1:], attrs)
 
 
-class IPAUser(IPAObject):
+class IPAUser(IPAObject, GenericUser):
     """
     IPA user management.
+
+    :class:`IPAUser` implements :class:`GenericUser` for static typing and provider-agnostic tests.
+    IPA-specific keyword arguments on :meth:`add` and :meth:`modify` are in addition to the generic API.
     """
 
     def __init__(self, role: IPA, name: str) -> None:
@@ -867,7 +896,7 @@ class IPAUser(IPAObject):
         *,
         uid: int | None = None,
         gid: int | None = None,
-        password: str | None = "Secret123",
+        password: str = "Secret123",
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
@@ -885,8 +914,8 @@ class IPAUser(IPAObject):
         :type uid: int | None, optional
         :param gid: Primary group id, defaults to None
         :type gid: int | None, optional
-        :param password: Password, defaults to 'Secret123'
-        :type password: str | None, optional
+        :param password: Password, defaults to 'Secret123' (use empty string to skip setting a password)
+        :type password: str, optional
         :param home: Home directory, defaults to None
         :type home: str | None, optional
         :param gecos: GECOS, defaults to None
@@ -913,7 +942,7 @@ class IPAUser(IPAObject):
             "homedir": (self.cli.option.VALUE, home),
             "gecos": (self.cli.option.VALUE, gecos),
             "shell": (self.cli.option.VALUE, shell),
-            "password": (self.cli.option.SWITCH, True) if password is not None else None,
+            "password": (self.cli.option.SWITCH, True) if password else None,
             "user-auth-type": (self.cli.option.VALUE, user_auth_type),
             "sshpubkey": (self.cli.option.VALUE, sshpubkey),
             "email": (self.cli.option.VALUE, email),
@@ -922,7 +951,7 @@ class IPAUser(IPAObject):
         if not require_password_reset:
             attrs["password-expiration"] = (self.cli.option.VALUE, "20380101120000Z")
 
-        self._add(attrs, input=password)
+        self._add(attrs, input=password or None)
         return self
 
     def modify(
@@ -996,6 +1025,20 @@ class IPAUser(IPAObject):
 
         self._modify(attrs, input=password)
         return self
+
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get user attributes.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericUser` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key (empty if the user does not exist).
+        :rtype: dict[str, list[str]] | None
+        """
+        result = super().get(attrs, opattrs=opattrs)
+        return result if result is not None else {}
 
     def reset(self, password: str | None = "Secret123") -> IPAUser:
         """
@@ -1122,12 +1165,14 @@ class IPAUser(IPAObject):
 
     def passkey_remove(self, passkey_mapping: str) -> IPAUser:
         """
-        Add passkey mapping from the user.
+        Remove passkey mapping from the user.
+
+        Implements :meth:`GenericUser.passkey_remove`.
 
         :param passkey_mapping: Passkey mapping generated by ``sssctl passkey-register``
         :type passkey_mapping: str
         :return: Self.
-        :rtype: IPAUser.
+        :rtype: IPAUser
         """
         self._exec("remove-passkey", [passkey_mapping])
         return self
@@ -1245,7 +1290,6 @@ class IDUserOverride(IPAUser):
         :type user: IPAUser
         """
         super().__init__(user.role, user.name)
-        self.name = user.name
 
     def add_override(
         self,
@@ -1485,9 +1529,13 @@ class IPASubID(BaseObject[IPAHost, IPA]):
         return self
 
 
-class IPAGroup(IPAObject):
+class IPAGroup(IPAObject, GenericGroup):
     """
     IPA group management.
+
+    :class:`IPAGroup` implements :class:`GenericGroup` for static typing and provider-agnostic tests.
+    IPA-specific keyword arguments on :meth:`add` and external members (``str``) on membership
+    methods are in addition to the generic API.
     """
 
     def __init__(self, role: IPA, name: str) -> None:
@@ -1559,67 +1607,78 @@ class IPAGroup(IPAObject):
         self._modify(attrs)
         return self
 
-    def add_member(self, member: IPAUser | IPAGroup | str) -> IPAGroup:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get group attributes.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericGroup` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key (empty if the group does not exist).
+        :rtype: dict[str, list[str]] | None
+        """
+        result = super().get(attrs, opattrs=opattrs)
+        return result if result is not None else {}
+
+    def add_member(self, member: GroupMemberField) -> IPAGroup:
         """
         Add group member.
 
-        Member can be either IPAUser, IPAGroup or a string in which case it
+        Member can be a :class:`GenericUser`, :class:`GenericGroup`, or a string in which case it
         is added as an external member.
 
         :param member: User or group to add as a member.
-        :type member: IPAUser | IPAGroup | str
+        :type member: GroupMemberField
         :return: Self.
         :rtype: IPAGroup
         """
         return self.add_members([member])
 
-    def add_members(self, members: list[IPAUser | IPAGroup | str]) -> IPAGroup:
+    def add_members(self, members: list[GroupMemberField]) -> IPAGroup:
         """
         Add multiple group members.
 
-        Member can be either IPAUser, IPAGroup or a string in which case it
-        is added as an external member.
+        Members can be :class:`GenericUser`, :class:`GenericGroup`, or strings (external members).
 
         :param members: List of users or groups to add as members.
-        :type members: list[IPAUser | IPAGroup | str]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: IPAGroup
         """
         self._exec("add-member", ipaargs=["--no-prompt"], args=self.__get_member_args(members))
         return self
 
-    def remove_member(self, member: IPAUser | IPAGroup | str) -> IPAGroup:
+    def remove_member(self, member: GroupMemberField) -> IPAGroup:
         """
         Remove group member.
 
-        Member can be either IPAUser, IPAGroup or a string in which case
-        an external member is removed.
+        Member can be a :class:`GenericUser`, :class:`GenericGroup`, or a string (external member).
 
         :param member: User or group to remove from the group.
-        :type member: IPAUser | IPAGroup | str
+        :type member: GroupMemberField
         :return: Self.
         :rtype: IPAGroup
         """
         return self.remove_members([member])
 
-    def remove_members(self, members: list[IPAUser | IPAGroup | str]) -> IPAGroup:
+    def remove_members(self, members: list[GroupMemberField]) -> IPAGroup:
         """
         Remove multiple group members.
 
-        Member can be either IPAUser, IPAGroup or a string in which case
-        an external member is removed.
+        Members can be :class:`GenericUser`, :class:`GenericGroup`, or strings (external members).
 
         :param members: List of users or groups to remove from the group.
-        :type members: list[IPAUser | IPAGroup | str]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: IPAGroup
         """
         self._exec("remove-member", ipaargs=["--no-prompt"], args=self.__get_member_args(members))
         return self
 
-    def __get_member_args(self, members: list[IPAUser | IPAGroup | str]) -> list[str]:
-        users = [x for item in members if isinstance(item, IPAUser) for x in ("--users", item.name)]
-        groups = [x for item in members if isinstance(item, IPAGroup) for x in ("--groups", item.name)]
+    def __get_member_args(self, members: list[GroupMemberField]) -> list[str]:
+        users = [x for item in members if isinstance(item, GenericUser) for x in ("--users", item.name)]
+        groups = [x for item in members if isinstance(item, GenericGroup) for x in ("--groups", item.name)]
         external = [x for item in members if isinstance(item, str) for x in ("--external", item)]
         return [*users, *groups, *external]
 
@@ -1656,7 +1715,6 @@ class IDGroupOverride(IPAGroup):
         :type user: IPAGroup
         """
         super().__init__(group.role, group.name)
-        self.name = group.name
 
     def add_override(
         self,
@@ -1766,9 +1824,13 @@ class IDGroupOverride(IPAGroup):
         return attrs_parse(lines)
 
 
-class IPANetgroup(IPAObject):
+class IPANetgroup(IPAObject, GenericNetgroup):
     """
     IPA netgroup management.
+
+    :class:`IPANetgroup` implements :class:`GenericNetgroup` for static typing and
+    provider-agnostic tests. IPA-specific ``group`` and ``hostgroup`` members on
+    :meth:`add_member` are in addition to the generic API.
     """
 
     def __init__(self, role: IPA, name: str) -> None:
@@ -1790,14 +1852,28 @@ class IPANetgroup(IPAObject):
         self._add()
         return self
 
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get netgroup attributes.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericNetgroup` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key (empty if the netgroup does not exist).
+        :rtype: dict[str, list[str]] | None
+        """
+        result = super().get(attrs, opattrs=opattrs)
+        return result if result is not None else {}
+
     def add_member(
         self,
         *,
         host: str | None = None,
-        user: IPAUser | str | None = None,
-        group: IPAGroup | str | None = None,
+        user: GenericUser | str | None = None,
+        group: GenericGroup | str | None = None,
         hostgroup: str | None = None,
-        ng: IPANetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> IPANetgroup:
         """
         Add netgroup member.
@@ -1805,24 +1881,24 @@ class IPANetgroup(IPAObject):
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: IPAUser | str | None, optional
-        :param group: Group, defaults to None
-        :type group: IPAGroup | str | None, optional
-        :param hostgroup: Hostgroup, defaults to None
+        :type user: GenericUser | str | None, optional
+        :param group: Group (IPA only), defaults to None
+        :type group: GenericGroup | str | None, optional
+        :param hostgroup: Hostgroup (IPA only), defaults to None
         :type hostgroup: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: IPANetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         :return: Self.
         :rtype: IPANetgroup
         """
         return self.add_members([IPANetgroupMember(host=host, user=user, group=group, hostgroup=hostgroup, ng=ng)])
 
-    def add_members(self, members: list[IPANetgroupMember]) -> IPANetgroup:
+    def add_members(self, members: list[GenericNetgroupMember]) -> IPANetgroup:
         """
         Add multiple netgroup members.
 
-        :param members: Netgroup members.
-        :type members: list[IPANetgroupMember]
+        :param members: Netgroup members (use :class:`IPANetgroupMember` for IPA group/hostgroup members).
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: IPANetgroup
         """
@@ -1833,10 +1909,10 @@ class IPANetgroup(IPAObject):
         self,
         *,
         host: str | None = None,
-        user: IPAUser | str | None = None,
-        group: IPAGroup | str | None = None,
+        user: GenericUser | str | None = None,
+        group: GenericGroup | str | None = None,
         hostgroup: str | None = None,
-        ng: IPANetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> IPANetgroup:
         """
         Remove netgroup member.
@@ -1844,35 +1920,45 @@ class IPANetgroup(IPAObject):
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: IPAUser | str | None, optional
-        :param group: Group, defaults to None
-        :type group: IPAGroup | str | None, optional
-        :param hostgroup: Hostgroup, defaults to None
+        :type user: GenericUser | str | None, optional
+        :param group: Group (IPA only), defaults to None
+        :type group: GenericGroup | str | None, optional
+        :param hostgroup: Hostgroup (IPA only), defaults to None
         :type hostgroup: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: IPANetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         :return: Self.
         :rtype: IPANetgroup
         """
         return self.remove_members([IPANetgroupMember(host=host, user=user, group=group, hostgroup=hostgroup, ng=ng)])
 
-    def remove_members(self, members: list[IPANetgroupMember]) -> IPANetgroup:
+    def remove_members(self, members: list[GenericNetgroupMember]) -> IPANetgroup:
         """
         Remove multiple netgroup members.
 
-        :param members: Netgroup members.
-        :type members: list[IPANetgroupMember]
+        :param members: Netgroup members (use :class:`IPANetgroupMember` for IPA group/hostgroup members).
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: IPANetgroup
         """
         self._exec("remove-member", self.__get_member_args(members))
         return self
 
-    def __get_member_args(self, members: list[IPANetgroupMember]) -> list[str]:
+    def __get_member_args(self, members: list[GenericNetgroupMember]) -> list[str]:
         users = [x for item in members if item.user is not None for x in ("--users", item.user)]
-        groups = [x for item in members if item.group is not None for x in ("--groups", item.group)]
+        groups = [
+            x
+            for item in members
+            if getattr(item, "group", None) is not None
+            for x in ("--groups", getattr(item, "group"))
+        ]
         hosts = [x for item in members if item.host is not None for x in ("--hosts", item.host)]
-        hostgroups = [x for item in members if item.hostgroup is not None for x in ("--hostgroups", item.hostgroup)]
+        hostgroups = [
+            x
+            for item in members
+            if getattr(item, "hostgroup", None) is not None
+            for x in ("--hostgroups", getattr(item, "hostgroup"))
+        ]
         netgroups = [x for item in members if item.netgroup is not None for x in ("--netgroups", item.netgroup)]
 
         return [*users, *groups, *hosts, *hostgroups, *netgroups]
@@ -1887,22 +1973,22 @@ class IPANetgroupMember(GenericNetgroupMember):
         self,
         *,
         host: str | None = None,
-        user: IPAUser | str | None = None,
-        group: IPAGroup | str | None = None,
+        user: GenericUser | str | None = None,
+        group: GenericGroup | str | None = None,
         hostgroup: str | None = None,
-        ng: IPANetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> None:
         """
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: IPAUser | str | None, optional
+        :type user: GenericUser | str | None, optional
         :param group: Group, defaults to None
-        :type group: IPAGroup | str | None, optional
+        :type group: GenericGroup | str | None, optional
         :param hostgroup: Hostgroup, defaults to None
         :type hostgroup: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: IPANetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         """
         super().__init__(host=host, user=user, ng=ng)
 
@@ -1990,9 +2076,12 @@ class IPAHostAccount(IPAObject):
         return self
 
 
-class IPASudoRule(IPAObject):
+class IPASudoRule(IPAObject, GenericSudoRule):
     """
     IPA sudo rule management.
+
+    :class:`IPASudoRule` implements :class:`GenericSudoRule` for static typing and
+    provider-agnostic tests.
     """
 
     def __init__(self, role: IPA, name: str) -> None:
@@ -2008,12 +2097,12 @@ class IPASudoRule(IPAObject):
     def add(
         self,
         *,
-        user: str | IPAUser | IPAGroup | list[str | IPAUser | IPAGroup] | None = None,
-        host: str | list[str] | None = None,
-        command: str | list[str] | None = None,
+        user: SudoRuleUserField = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: str | IPAUser | IPAGroup | list[str | IPAUser | IPAGroup] | None = None,
-        runasgroup: str | IPAGroup | list[str | IPAGroup] | None = None,
+        runasuser: SudoRuleRunAsUserField = None,
+        runasgroup: SudoRuleRunAsGroupField = None,
         order: int | None = None,
         nopasswd: bool | None = None,
     ) -> IPASudoRule:
@@ -2021,22 +2110,22 @@ class IPASudoRule(IPAObject):
         Create new sudo rule.
 
         :param user: sudoUser attribute, defaults to None
-        :type user: str | IPAUser | IPAGroup | list[str  |  IPAUser  |  IPAGroup] | None, optional
+        :type user: SudoRuleUserField, optional
         :param host: sudoHost attribute, defaults to None
-        :type host: str | list[str] | None, optional
+        :type host: SudoRuleHostField, optional
         :param command: sudoCommand attribute, defaults to None
-        :type command: str | list[str] | None, optional
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None
-        :type runasuser: str | IPAUser | IPAGroup | list[str  |  IPAUser  |  IPAGroup] | None, optional
+        :type runasuser: SudoRuleRunAsUserField, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
-        :type runasgroup: str | IPAGroup | list[str  |  IPAGroup] | None, optional
+        :type runasgroup: SudoRuleRunAsGroupField, optional
         :param order: sudoOrder attribute, defaults to None
         :type order: int | None, optional
         :param nopasswd: If true, no authentication is required (NOPASSWD), defaults to None (no change)
         :type nopasswd: bool | None, optional
-        :return: _description_
+        :return: Self.
         :rtype: IPASudoRule
         """
         # Remember arguments so we can use them in modify if needed
@@ -2117,12 +2206,12 @@ class IPASudoRule(IPAObject):
     def modify(
         self,
         *,
-        user: str | IPAUser | IPAGroup | list[str | IPAUser | IPAGroup] | None = None,
-        host: str | list[str] | None = None,
-        command: str | list[str] | None = None,
+        user: SudoRuleUserField = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: str | IPAUser | IPAGroup | list[str | IPAUser | IPAGroup] | None = None,
-        runasgroup: str | IPAGroup | list[str | IPAGroup] | None = None,
+        runasuser: SudoRuleRunAsUserField = None,
+        runasgroup: SudoRuleRunAsGroupField = None,
         order: int | None = None,
         nopasswd: bool | None = None,
     ) -> IPASudoRule:
@@ -2130,22 +2219,22 @@ class IPASudoRule(IPAObject):
         Modify existing IPA sudo rule.
 
         :param user: sudoUser attribute, defaults to None
-        :type user: str | IPAUser | IPAGroup | list[str  |  IPAUser  |  IPAGroup] | None, optional
+        :type user: SudoRuleUserField, optional
         :param host: sudoHost attribute, defaults to None
-        :type host: str | list[str] | None, optional
+        :type host: SudoRuleHostField, optional
         :param command: sudoCommand attribute, defaults to None
-        :type command: str | list[str] | None, optional
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None
-        :type runasuser: str | IPAUser | IPAGroup | list[str  |  IPAUser  |  IPAGroup] | None, optional
+        :type runasuser: SudoRuleRunAsUserField, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
-        :type runasgroup: str | IPAGroup | list[str  |  IPAGroup] | None, optional
+        :type runasgroup: SudoRuleRunAsGroupField, optional
         :param order: sudoOrder attribute, defaults to None
         :type order: int | None, optional
         :param nopasswd: If true, no authentication is required (NOPASSWD), defaults to None (no change)
         :type nopasswd: bool | None, optional
-        :return: _description_
+        :return: Self.
         :rtype: IPASudoRule
         """
         self.delete()
@@ -2162,6 +2251,20 @@ class IPASudoRule(IPAObject):
 
         return self
 
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get sudo rule attributes.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericSudoRule` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key (empty if the rule does not exist).
+        :rtype: dict[str, list[str]] | None
+        """
+        result = super().get(attrs, opattrs=opattrs)
+        return result if result is not None else {}
+
     def delete(self) -> None:
         """
         Delete sudo rule from IPA.
@@ -2170,7 +2273,7 @@ class IPASudoRule(IPAObject):
         self.role.host.conn.run(f'ipa sudocmdgroup-del "{self.name}_allow"')
         self.role.host.conn.run(f'ipa sudocmdgroup-del "{self.name}_deny"')
 
-    def __get_commands(self, value: str | list[str] | None) -> tuple[list[str], list[str], str]:
+    def __get_commands(self, value: SudoRuleCommandField) -> tuple[list[str], list[str], str]:
         allow_commands = []
         deny_commands = []
         category = ""
@@ -2187,7 +2290,7 @@ class IPASudoRule(IPAObject):
 
         return allow_commands, deny_commands, category
 
-    def __get_hosts(self, value: str | list[str] | None) -> tuple[list[str], str]:
+    def __get_hosts(self, value: SudoRuleHostField) -> tuple[list[str], str]:
         hosts = []
         category = ""
         for host in to_list_of_strings(value):
@@ -2200,7 +2303,7 @@ class IPASudoRule(IPAObject):
         return hosts, category
 
     def __get_users_and_groups(
-        self, value: str | IPAUser | IPAGroup | list[str | IPAUser | IPAGroup] | None
+        self, value: SudoRuleUserField | SudoRuleRunAsUserField
     ) -> tuple[list[str], list[str], str]:
         users = []
         groups = []
@@ -2210,7 +2313,7 @@ class IPASudoRule(IPAObject):
                 category = "--usercat=all"
                 continue
 
-            if isinstance(item, IPAGroup):
+            if isinstance(item, GenericGroup):
                 groups.append(item.name)
                 continue
 
@@ -2218,7 +2321,7 @@ class IPASudoRule(IPAObject):
                 groups.append(item[1:])
                 continue
 
-            if isinstance(item, IPAUser):
+            if isinstance(item, GenericUser):
                 users.append(item.name)
                 continue
 
@@ -2226,20 +2329,22 @@ class IPASudoRule(IPAObject):
                 users.append(item)
                 continue
 
+            if hasattr(item, "name"):
+                users.append(item.name)
+                continue
+
             raise ValueError(f"Unsupported type: {type(item)}")
 
         return users, groups, category
 
-    def __get_run_as_user(
-        self, value: str | IPAUser | IPAGroup | list[str | IPAUser | IPAGroup] | None
-    ) -> tuple[list[str], list[str], str]:
+    def __get_run_as_user(self, value: SudoRuleRunAsUserField) -> tuple[list[str], list[str], str]:
         users, groups, category = self.__get_users_and_groups(value)
         if category:
             category = "--runasusercat=all"
 
         return users, groups, category
 
-    def __get_run_as_group(self, value: str | IPAGroup | list[str | IPAGroup] | None) -> tuple[list[str], str]:
+    def __get_run_as_group(self, value: SudoRuleRunAsGroupField) -> tuple[list[str], str]:
         groups = []
         category = ""
         for item in to_list(value):
@@ -2247,12 +2352,16 @@ class IPASudoRule(IPAObject):
                 category = "--runasgroupcat=all"
                 continue
 
-            if isinstance(item, IPAGroup):
+            if isinstance(item, GenericGroup):
                 groups.append(item.name)
                 continue
 
             if isinstance(item, str):
                 groups.append(item)
+                continue
+
+            if hasattr(item, "name"):
+                groups.append(item.name)
                 continue
 
             raise ValueError(f"Unsupported type: {type(item)}")
@@ -2274,9 +2383,13 @@ class IPASudoRule(IPAObject):
             self.role.host.conn.run(f'ipa {cmd} "{name}" {args}')
 
 
-class IPAAutomount(object):
+class IPAAutomount(GenericAutomount):
     """
     IPA automount management.
+
+    :class:`IPAAutomount` implements :class:`GenericAutomount` for static typing and
+    provider-agnostic tests. The optional ``location`` argument on :meth:`map` is
+    IPA-specific; :meth:`location` is not part of the generic API.
     """
 
     def __init__(self, role: IPA) -> None:
@@ -2301,6 +2414,9 @@ class IPAAutomount(object):
         """
         Get automount map object.
 
+        Implements :meth:`GenericAutomount.map`; ``location`` selects the IPA automount
+        location (defaults to ``default``).
+
         :param name: Automount map name.
         :type name: str
         :param location: Automount map location, defaults to ``default``
@@ -2310,17 +2426,21 @@ class IPAAutomount(object):
         """
         return IPAAutomountMap(self.__role, name, location)
 
-    def key(self, name: str, map: IPAAutomountMap) -> IPAAutomountKey:
+    def key(self, name: str, map: GenericAutomountMap) -> IPAAutomountKey:
         """
         Get automount key object.
+
+        Implements :meth:`GenericAutomount.key`.
 
         :param name: Automount key name.
         :type name: str
         :param map: Automount map that is a parent to this key.
-        :type map: IPAAutomountMap
+        :type map: GenericAutomountMap
         :return: New automount key object.
         :rtype: IPAAutomountKey
         """
+        if not isinstance(map, IPAAutomountMap):
+            raise TypeError("IPA automount keys require an IPAAutomountMap parent map.")
         return IPAAutomountKey(self.__role, name, map)
 
 
@@ -2373,9 +2493,12 @@ class IPAAutomountLocation(IPAObject):
         return IPAAutomountMap(self.role, name, self)
 
 
-class IPAAutomountMap(IPAObject):
+class IPAAutomountMap(IPAObject, GenericAutomountMap):
     """
     IPA automount map management.
+
+    :class:`IPAAutomountMap` implements :class:`GenericAutomountMap` for static typing
+    and provider-agnostic tests.
     """
 
     def __init__(self, role: IPA, name: str, location: IPAAutomountLocation | str = "default") -> None:
@@ -2444,6 +2567,20 @@ class IPAAutomountMap(IPAObject):
         self._add()
         return self
 
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get automount map attributes.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericAutomountMap` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key (empty if the map does not exist).
+        :rtype: dict[str, list[str]] | None
+        """
+        result = super().get(attrs, opattrs=opattrs)
+        return result if result is not None else {}
+
     def key(self, name: str) -> IPAAutomountKey:
         """
         Get automount key object for this map.
@@ -2456,9 +2593,12 @@ class IPAAutomountMap(IPAObject):
         return IPAAutomountKey(self.role, name, self)
 
 
-class IPAAutomountKey(IPAObject):
+class IPAAutomountKey(IPAObject, GenericAutomountKey):
     """
     IPA automount key management.
+
+    :class:`IPAAutomountKey` implements :class:`GenericAutomountKey` for static typing
+    and provider-agnostic tests.
     """
 
     def __init__(
@@ -2512,12 +2652,26 @@ class IPAAutomountKey(IPAObject):
         )
         return self.role.host.conn.exec(["ipa", *ipaargs, f"{self.command_group}-{op}", *defargs, *args], **kwargs)
 
-    def add(self, *, info: str | NFSExport | IPAAutomountMap) -> IPAAutomountKey:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get automount key attributes.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericAutomountKey` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key (empty if the key does not exist).
+        :rtype: dict[str, list[str]] | None
+        """
+        result = super().get(attrs, opattrs=opattrs)
+        return result if result is not None else {}
+
+    def add(self, *, info: str | NFSExport | GenericAutomountMap) -> IPAAutomountKey:
         """
         Create new IPA automount key.
 
         :param info: Automount information
-        :type info: str | NFSExport | IPAAutomountMap
+        :type info: str | NFSExport | GenericAutomountMap
         :return: Self.
         :rtype: IPAAutomountKey
         """
@@ -2531,13 +2685,13 @@ class IPAAutomountKey(IPAObject):
     def modify(
         self,
         *,
-        info: str | NFSExport | IPAAutomountMap | None = None,
+        info: str | NFSExport | GenericAutomountMap | None = None,
     ) -> IPAAutomountKey:
         """
         Modify existing IPA automount key.
 
         :param info: Automount information, defaults to ``None``
-        :type info: str | NFSExport | IPAAutomountMap | None
+        :type info: str | NFSExport | GenericAutomountMap | None
         :return: Self.
         :rtype: IPAAutomountKey
         """
@@ -2574,11 +2728,11 @@ class IPAAutomountKey(IPAObject):
         """
         return self.dump()
 
-    def __get_info(self, info: str | NFSExport | IPAAutomountMap | None) -> str | None:
+    def __get_info(self, info: str | NFSExport | GenericAutomountMap | None) -> str | None:
         if isinstance(info, NFSExport):
             return info.get()
 
-        if isinstance(info, IPAAutomountMap):
+        if isinstance(info, GenericAutomountMap):
             return info.name
 
         return info
@@ -2586,17 +2740,26 @@ class IPAAutomountKey(IPAObject):
 
 class IPAPasswordPolicy(IPAObject, GenericPasswordPolicy):
     """
-    Password policy management.
+    IPA password policy management.
+
+    :class:`IPAPasswordPolicy` implements :class:`GenericPasswordPolicy` for static typing
+    and provider-agnostic tests.
     """
 
-    def __init__(self, role: IPA, name: str = "ipausers"):
+    def __init__(self, role: IPA, name: str = "ipausers") -> None:
         """
-        :param role: IPA host object.
-        :type role: IPAHost
+        :param role: IPA role object.
+        :type role: IPA
         :param name: Name of target object, defaults to 'ipausers'.
         :type name: str
         """
         super().__init__(role, name, command_group="pwpolicy")
+
+    def _apply_attrs(self, attrs: CLIBuilderArgs) -> None:
+        if self.get() is None:
+            self._add(attrs)
+        else:
+            self._modify(attrs)
 
     def complexity(self, enable: bool) -> IPAPasswordPolicy:
         """
@@ -2604,13 +2767,11 @@ class IPAPasswordPolicy(IPAObject, GenericPasswordPolicy):
 
         :param enable: Enable or disable password complexity.
         :type enable: bool
-        :return: IPAPasswordPolicy object.
+        :return: Self.
         :rtype: IPAPasswordPolicy
         """
-        attrs: CLIBuilderArgs
-
         if enable:
-            attrs = {
+            attrs: CLIBuilderArgs = {
                 "dictcheck": (self.cli.option.VALUE, "True"),
                 "usercheck": (self.cli.option.VALUE, "True"),
                 "minlength": (self.cli.option.VALUE, 8),
@@ -2626,11 +2787,7 @@ class IPAPasswordPolicy(IPAObject, GenericPasswordPolicy):
                 "priority": (self.cli.option.VALUE, 1),
             }
 
-        if self.get() is None:
-            self._add(attrs)
-        else:
-            self._modify(attrs)
-
+        self._apply_attrs(attrs)
         return self
 
     def lockout(self, duration: int, attempts: int) -> IPAPasswordPolicy:
@@ -2641,15 +2798,14 @@ class IPAPasswordPolicy(IPAObject, GenericPasswordPolicy):
         :type duration: int
         :param attempts: Number of login attempts.
         :type attempts: int
-        :return: IPAPasswordPolicy object.
+        :return: Self.
         :rtype: IPAPasswordPolicy
         """
         attrs: CLIBuilderArgs = {
             "lockouttime": (self.cli.option.VALUE, str(duration)),
             "maxfail": (self.cli.option.VALUE, str(attempts)),
         }
-        self._add(attrs)
-
+        self._apply_attrs(attrs)
         return self
 
 
@@ -2743,15 +2899,18 @@ class IPAIDView(IPAObject):
         self._exec("del", ["--continue"])
 
 
-class IPADNSServer(BaseObject[IPAHost, IPA]):
+class IPADNSServer(GenericDNSServer):
     """
-    DNS management utilities.
+    IPA DNS server management.
+
+    :class:`IPADNSServer` implements :class:`GenericDNSServer` for static typing and
+    provider-agnostic tests.
     """
 
-    def __init__(self, role: IPA):
+    def __init__(self, role: IPA) -> None:
         """
-        :param role: IPA host object.
-        :type role: ADHost
+        :param role: IPA role object.
+        :type role: IPA
         """
         super().__init__(role)
 
@@ -2763,29 +2922,35 @@ class IPADNSServer(BaseObject[IPAHost, IPA]):
 
     def zone(self, name: str) -> IPADNSZone:
         """
-        Get IPADNSZone object.
+        Get DNS zone object.
+
+        Implements :meth:`GenericDNSServer.zone`.
 
         :param name: Zone name.
         :type name: str
-        :return: IPADNSZone object.
+        :return: DNS zone object.
         :rtype: IPADNSZone
         """
         return IPADNSZone(self.role, name)
 
-    def get_forwarders(self) -> list[str] | None:
+    def get_forwarders(self) -> list[str]:
         """
         Get DNS global forwarders.
 
-        :return: DNS global forwarders.:
-        :rtype: list[str] | None
+        Implements :meth:`GenericDNSServer.get_forwarders`.
+
+        :return: List of forwarder IP addresses (empty if none are configured).
+        :rtype: list[str]
         """
         result = self.host.conn.run("ipa dnsconfig-show --raw").stdout_lines
         result = [line.strip() for line in result if line.startswith(" ")]
         if result is not None and isinstance(result, list):
             forwarders = attrs_parse(result, ["idnsforwarders"])
             if forwarders is not None and isinstance(forwarders, dict):
-                return forwarders.get("idnsforwarders")
-        return None
+                value = forwarders.get("idnsforwarders")
+                if value is not None:
+                    return to_list_of_strings(value)
+        return []
 
     def add_forwarder(self, ip_address: str) -> IPADNSServer:
         """
@@ -2801,7 +2966,7 @@ class IPADNSServer(BaseObject[IPAHost, IPA]):
 
     def remove_forwarder(self, ip_address: str) -> None:
         """
-        Remove DNS server forwarders.
+        Remove a DNS server forwarder.
 
         :param ip_address: IP address.
         :type ip_address: str
@@ -2809,7 +2974,7 @@ class IPADNSServer(BaseObject[IPAHost, IPA]):
         forwarders = self.get_forwarders()
         if forwarders and ip_address in forwarders:
             forwarders = [fwd for fwd in forwarders if fwd != ip_address]
-            self.host.conn.run(f"ipa dnsconfig-mod --forwarder \"{' '.join(forwarders)}\"")
+            self.host.conn.run(f'ipa dnsconfig-mod --forwarder "{" ".join(forwarders)}"')
 
     def clear_forwarders(self) -> None:
         """
@@ -2823,35 +2988,40 @@ class IPADNSServer(BaseObject[IPAHost, IPA]):
             for forwarder in forwarders:
                 self.remove_forwarder(forwarder)
 
-    def list_zones(self) -> list[str] | None:
+    def list_zones(self) -> list[str]:
         """
         List zones.
-        :return: List of zones.
-        :rtype: dict[str, list[str]] | None"
+
+        Implements :meth:`GenericDNSServer.list_zones`.
+
+        :return: List of zone names (empty if none are found).
+        :rtype: list[str]
         """
         result = self.host.conn.run("ipa dnszone-find --raw").stdout_lines
         result = [line.strip() for line in result if line.startswith(" ")]
         if result is None:
-            raise ValueError("No zones found.")
-        else:
-            zones = [line.rstrip(".") for line in result]
-            parsed_result = attrs_parse(zones, ["idnsname"])
-            if isinstance(parsed_result, dict):
-                if isinstance(parsed_result["idnsname"], list):
-                    return parsed_result.get("idnsname")
-            else:
-                return None
+            return []
+        zones = [line.rstrip(".") for line in result]
+        parsed_result = attrs_parse(zones, ["idnsname"])
+        if isinstance(parsed_result, dict):
+            idnsname = parsed_result.get("idnsname")
+            if isinstance(idnsname, list):
+                return idnsname
+        return []
 
 
-class IPADNSZone(IPADNSServer):
+class IPADNSZone(IPADNSServer, GenericDNSZone):
     """
-    DNS zone management.
+    IPA DNS zone management.
+
+    :class:`IPADNSZone` implements :class:`GenericDNSZone` for static typing and
+    provider-agnostic tests.
     """
 
-    def __init__(self, role: IPA, name: str):
+    def __init__(self, role: IPA, name: str) -> None:
         """
-        :param role: IPA host object.
-        :type role: IPAHost
+        :param role: IPA role object.
+        :type role: IPA
         :param name: DNS zone name.
         :type name: str
         """
@@ -2864,8 +3034,10 @@ class IPADNSZone(IPADNSServer):
         """
         Create new zone.
 
-        :return: IPADNSServer object.
-        :rtype: IPADNSServer
+        Implements :meth:`GenericDNSZone.create`.
+
+        :return: Self.
+        :rtype: IPADNSZone
         """
         self.host.conn.run(f"ipa dnszone-add {self.zone_name} --skip-overlap-check")
         self.host.conn.run(f"ipa dnszone-mod {self.zone_name} --dynamic-update=TRUE --allow-sync-ptr=TRUE")
@@ -2874,12 +3046,16 @@ class IPADNSZone(IPADNSServer):
     def delete(self) -> None:
         """
         Delete zone.
+
+        Implements :meth:`GenericDNSZone.delete`.
         """
         self.host.conn.run(f"dnszone-del {self.zone_name}")
 
     def add_record(self, name: str, data: str | int) -> IPADNSZone:
         """
         Add DNS record.
+
+        Implements :meth:`GenericDNSZone.add_record`.
 
         If ``data`` is a str, a forward record will be added.
         If an integer a reverse record will be added.
@@ -2888,7 +3064,7 @@ class IPADNSZone(IPADNSServer):
         :type name: str
         :param data: Record data.
         :type data: str | int
-        :return: IPADNSZone object.
+        :return: Self.
         :rtype: IPADNSZone
         """
         args = ""
@@ -2911,7 +3087,9 @@ class IPADNSZone(IPADNSServer):
         """
         Delete DNS record, both forward and reverse records are deleted.
 
-        :param name: Name.
+        Implements :meth:`GenericDNSZone.delete_record`.
+
+        :param name: Name of the record.
         :type name: str
         """
         if self.domain not in name:
@@ -2941,9 +3119,11 @@ class IPADNSZone(IPADNSServer):
 
     def print(self) -> str:
         """
-        Prints all dns records in a zone as text.
+        Print all DNS records in a zone as text.
 
-        :return: Print zone data.
+        Implements :meth:`GenericDNSZone.print`.
+
+        :return: Zone data as text.
         :rtype: str
         """
         result = self.host.conn.run(f"ipa dnszone-show {self.zone_name}").stdout
@@ -2952,10 +3132,12 @@ class IPADNSZone(IPADNSServer):
 
 class IPACertificateAuthority(GenericCertificateAuthority):
     """
-    Provides helper methods for FreeIPA Certificate Authority operations.
+    FreeIPA Certificate Authority operations.
 
-    This class allows requesting, revoking, placing/removing certificate holds,
-    and retrieving certificate information via the ipa CLI.
+    :class:`IPACertificateAuthority` implements :class:`GenericCertificateAuthority` for
+    static typing and provider-agnostic tests. It requests, revokes, places/removes
+    certificate holds, and retrieves certificate information via the ``ipa`` CLI.
+    :meth:`request` accepts IPA-specific keyword arguments in addition to the generic API.
 
     .. code-block:: python
        :caption: Example usage
@@ -3020,9 +3202,13 @@ class IPACertificateAuthority(GenericCertificateAuthority):
         subject: Optional[str] = None,
         add_service: bool = False,
         key_size: int = 2048,
+        **kwargs: Any,
     ) -> tuple[str, str, str]:
         """
         Request a certificate from the IPA CA.
+
+        Implements :meth:`GenericCertificateAuthority.request`; ``principal`` is passed
+        positionally or as the first argument. Extra ``**kwargs`` are ignored.
 
         :param principal: The principal (user or service) name.
         :type principal: str
@@ -3037,6 +3223,7 @@ class IPACertificateAuthority(GenericCertificateAuthority):
         :raises ValueError: If subject cannot be derived from principal.
         :raises RuntimeError: If CSR generation fails.
         """
+        del kwargs
         base = re.sub(r"[^a-zA-Z0-9.\_-]", "_", principal)
         key_path = os.path.join(self.temp_dir, f"{base}.key")
         csr_path = os.path.join(self.temp_dir, f"{base}.csr")
@@ -3069,6 +3256,8 @@ class IPACertificateAuthority(GenericCertificateAuthority):
         """
         Revoke a certificate in IPA.
 
+        Implements :meth:`GenericCertificateAuthority.revoke`.
+
         :param cert_path: Path to the certificate file.
         :type cert_path: str
         :param reason: Reason for revocation.
@@ -3089,6 +3278,8 @@ class IPACertificateAuthority(GenericCertificateAuthority):
         """
         Place a certificate on hold.
 
+        Implements :meth:`GenericCertificateAuthority.revoke_hold`.
+
         :param cert_path: Path to the certificate file.
         :type cert_path: str
         """
@@ -3097,6 +3288,8 @@ class IPACertificateAuthority(GenericCertificateAuthority):
     def revoke_hold_remove(self, cert_path: str) -> None:
         """
         Remove hold from a certificate.
+
+        Implements :meth:`GenericCertificateAuthority.revoke_hold_remove`.
 
         :param cert_path: Path to the certificate file.
         :type cert_path: str
@@ -3111,6 +3304,9 @@ class IPACertificateAuthority(GenericCertificateAuthority):
     def get(self, cert_path: str) -> dict[str, list[str]]:
         """
         Retrieve certificate details from IPA.
+
+        Implements :meth:`GenericCertificateAuthority.get`.
+
         :param cert_path: Path to the certificate file.
         :type cert_path: str
         :returns: A dictionary of certificate attributes.

--- a/sssd_test_framework/roles/keycloak.py
+++ b/sssd_test_framework/roles/keycloak.py
@@ -156,7 +156,7 @@ class KeycloakUser(KeycloakObject):
 
         self.id = result.stderr.split()[-1].strip("'")
 
-        set_password = "set-password -r master " f"--username {self.name} " f"--new-password {password}"
+        set_password = f"set-password -r master --username {self.name} --new-password {password}"
         self.role.kcadm(set_password)
 
         return self

--- a/sssd_test_framework/roles/ldap.py
+++ b/sssd_test_framework/roles/ldap.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 from datetime import datetime
 from enum import Enum
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeAlias, TypeVar, cast
 
 import ldap
 import ldap.ldapobject
@@ -14,7 +14,25 @@ from ..hosts.ldap import LDAPHost
 from ..misc import attrs_include_value, to_list_without_none
 from ..utils.ldap import LDAPRecordAttributes, LDAPUtils
 from .base import BaseLinuxLDAPRole, BaseObject, DeleteAttribute, HostType
-from .generic import GenericNetgroupMember, GenericPasswordPolicy, ProtocolName
+from .generic import (
+    GenericAutomount,
+    GenericAutomountKey,
+    GenericAutomountMap,
+    GenericGroup,
+    GenericNetgroup,
+    GenericNetgroupMember,
+    GenericOrganizationalUnit,
+    GenericPasswordPolicy,
+    GenericSudoRule,
+    GenericUser,
+    GroupMemberField,
+    ProtocolName,
+    SudoRuleCommandField,
+    SudoRuleHostField,
+    SudoRuleRunAsGroupField,
+    SudoRuleRunAsUserField,
+    SudoRuleUserField,
+)
 from .nfs import NFSExport
 
 __all__ = [
@@ -39,9 +57,16 @@ __all__ = [
 
 
 LDAPRoleType = TypeVar("LDAPRoleType", bound=BaseLinuxLDAPRole)
-LDAPUserType = TypeVar("LDAPUserType", bound=ProtocolName)
-LDAPGroupType = TypeVar("LDAPGroupType", bound=ProtocolName)
-LDAPNetgroupType = TypeVar("LDAPNetgroupType", bound=ProtocolName)
+LDAPUserType = TypeVar("LDAPUserType", bound=GenericUser)
+LDAPGroupType = TypeVar("LDAPGroupType", bound=GenericGroup)
+LDAPNetgroupType = TypeVar("LDAPNetgroupType", bound=GenericNetgroup)
+
+_LDAPSudoUserInput: TypeAlias = SudoRuleUserField | int | list[SudoRuleUserField | int] | DeleteAttribute | None
+_LDAPSudoRunAsGroupInput: TypeAlias = (
+    SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | DeleteAttribute | None
+)
+_LDAPSudoUserAtom: TypeAlias = str | int | LDAPUserType | LDAPGroupType | GenericUser | GenericGroup | ProtocolName
+_LDAPSudoGroupAtom: TypeAlias = str | int | LDAPGroupType | GenericGroup | ProtocolName
 
 
 class LDAP(BaseLinuxLDAPRole[LDAPHost]):
@@ -652,7 +677,7 @@ class LDAPObject(BaseObject[HostType, LDAPRoleType]):
         """
         self.role.ldap.delete(self.dn)
 
-    def get(self, attrs: list[str] | None = None, opattrs: bool = False) -> dict[str, list[str]] | None:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get LDAP record attributes.
 
@@ -735,9 +760,12 @@ class LDAPACI(object):
         self.ldap.modify(self.dn, delete={"aci": value})
 
 
-class LDAPOrganizationalUnit(LDAPObject[HostType, LDAPRoleType]):
+class LDAPOrganizationalUnit(LDAPObject[HostType, LDAPRoleType], GenericOrganizationalUnit):
     """
     LDAP organizational unit management.
+
+    :class:`LDAPOrganizationalUnit` implements :class:`GenericOrganizationalUnit` for static
+    typing and provider-agnostic tests.
     """
 
     def __init__(self, role: LDAPRoleType, name: str, basedn: LDAPObject | str | None = None) -> None:
@@ -751,22 +779,46 @@ class LDAPOrganizationalUnit(LDAPObject[HostType, LDAPRoleType]):
         """
         super().__init__(role, name, f"ou={name}", basedn)
 
-    def add(self) -> LDAPOrganizationalUnit:
+    @property
+    def name(self) -> str:
+        """
+        OU name.
+
+        Implements :attr:`GenericOrganizationalUnit.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def add(self, name: str | None = None) -> LDAPOrganizationalUnit:
         """
         Create new LDAP organizational unit.
 
+        Implements :meth:`GenericOrganizationalUnit.add`. The optional ``name`` argument
+        is accepted for API compatibility; the OU name is taken from the provider ``ou()``
+        factory.
+
+        :param name: Unused; OU name is set when the object is created.
+        :type name: str | None
         :return: Self.
         :rtype: LDAPOrganizationalUnit
         """
+        _ = name
         attrs: LDAPRecordAttributes = {"objectClass": "organizationalUnit", "ou": self.name}
 
         self._add(attrs)
         return self
 
 
-class LDAPUser(LDAPObject[LDAPHost, LDAP]):
+class LDAPUser(LDAPObject[LDAPHost, LDAP], GenericUser):
     """
     LDAP user management.
+
+    :class:`LDAPUser` implements :class:`GenericUser` for static typing and provider-agnostic
+    tests. LDAP-specific keyword arguments on :meth:`add` and :meth:`modify` are in addition
+    to the generic API.
     """
 
     def __init__(
@@ -787,12 +839,25 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         self.first_passkey_add = False
         """Whether the 'passkeyUser' objectClass has already been added."""
 
+    @property
+    def name(self) -> str:
+        """
+        User name.
+
+        Implements :attr:`GenericUser.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
     def add(
         self,
         *,
         uid: int | None = None,
         gid: int | None = None,
-        password: str | None = "Secret123",
+        password: str = "Secret123",
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
@@ -808,8 +873,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         """
         Create new LDAP user.
 
-        User and group id is assigned automatically if they are not set. Other
-        parameters that are not set are ignored.
+        Implements :meth:`GenericUser.add`. User and group id is assigned automatically if
+        they are not set. Other parameters that are not set are ignored.
 
         :param uid: User id, defaults to None
         :type uid: int | None, optional
@@ -901,8 +966,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         """
         Modify existing LDAP user.
 
-        Parameters that are not set are ignored. If needed, you can delete an
-        attribute by setting the value to :attr:`Delete`.
+        Implements :meth:`GenericUser.modify`. Parameters that are not set are ignored.
+        If needed, you can delete an attribute by setting the value to :attr:`Delete`.
 
         :param uid: User id, defaults to None
         :type uid: int | DeleteAttribute | None, optional
@@ -962,6 +1027,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         """
         Reset user password.
 
+        Implements :meth:`GenericUser.reset`.
+
         :param password: Password, defaults to 'Secret123'
         :type password: str, optional
         :return: Self.
@@ -970,15 +1037,18 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         self.modify(password=password)
         return self
 
-    def expire(self, expiration: str = "19700101000000") -> LDAPUser:
+    def expire(self, expiration: str | None = "19700101000000") -> LDAPUser:
         """
         Set user password expiration date and time.
 
         :param expiration: Date and time for user password expiration, defaults to 19700101000000
-        :type expirataion: str, optional
+        :type expiration: str | None, optional
         :return: Self.
-        :rtype: IPAUser
+        :rtype: LDAPUser
         """
+        if expiration is None:
+            expiration = "19700101000000"
+
         start = datetime.now()
         end = datetime.strptime(expiration, "%Y%m%d%H%M%S")
         time_diff = end - start
@@ -994,6 +1064,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         """
         Force user to change password next logon.
 
+        Implements :meth:`GenericUser.password_change_at_logon`.
+
         :return: Self.
         :rtype: LDAPUser
         """
@@ -1008,6 +1080,8 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
     def passkey_add(self, passkey_mapping: str) -> LDAPUser:
         """
         Add passkey mapping to the user.
+
+        Implements :meth:`GenericUser.passkey_add`.
 
         :param passkey_mapping: Passkey mapping generated by ``sssctl passkey-register``
         :type passkey_mapping: str
@@ -1030,19 +1104,25 @@ class LDAPUser(LDAPObject[LDAPHost, LDAP]):
         """
         Remove passkey mapping from the user.
 
+        Implements :meth:`GenericUser.passkey_remove`.
+
         :param passkey_mapping: Passkey mapping generated by ``sssctl passkey-register``
         :type passkey_mapping: str
         :return: Self.
-        :rtype: LDAPUser.
+        :rtype: LDAPUser
         """
         attrs: LDAPRecordAttributes = {"objectClass": "passkeyUser", "passkey": passkey_mapping}
         self._modify(delete=attrs)
         return self
 
 
-class LDAPGroup(LDAPObject[LDAPHost, LDAP]):
+class LDAPGroup(LDAPObject[LDAPHost, LDAP], GenericGroup):
     """
     LDAP group management.
+
+    :class:`LDAPGroup` implements :class:`GenericGroup` for static typing and provider-agnostic
+    tests. LDAP-specific keyword arguments on :meth:`add` and :meth:`modify` are in addition to
+    the generic API.
     """
 
     def __init__(
@@ -1070,33 +1150,58 @@ class LDAPGroup(LDAPObject[LDAPHost, LDAP]):
             self.object_class = ["posixGroup", "groupOfNames"]
             self.member_attr = "member"
 
-    def __members(self, values: list[LDAPUser | LDAPGroup | str] | None) -> list[str] | None:
+    @property
+    def name(self) -> str:
+        """
+        Group name.
+
+        Implements :attr:`GenericGroup.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def __member_dn(self, member: GroupMemberField) -> str:
+        if isinstance(member, LDAPObject):
+            return member.dn
+        if isinstance(member, str):
+            return self._dn(member)
+        return self._dn(member.name)
+
+    def __member_name(self, member: GroupMemberField) -> str:
+        if isinstance(member, str):
+            return member
+        return member.name
+
+    def __members(self, values: list[GroupMemberField] | None) -> list[str] | None:
         if values is None:
             return None
 
         if self.rfc2307bis:
-            return [x.dn if isinstance(x, LDAPObject) else self._dn(x) for x in values]
+            return [self.__member_dn(x) for x in values]
 
-        return [x.name if isinstance(x, LDAPObject) else x for x in values]
+        return [self.__member_name(x) for x in values]
 
     def add(
         self,
         *,
         gid: int | None = None,
-        members: list[LDAPUser | LDAPGroup | str] | None = None,
+        members: list[GroupMemberField] | None = None,
         password: str | None = None,
         description: str | None = None,
     ) -> LDAPGroup:
         """
         Create new LDAP group.
 
-        Group id is assigned automatically if it is not set. Other parameters
-        that are not set are ignored.
+        Implements :meth:`GenericGroup.add`. Group id is assigned automatically if it is not
+        set. Other parameters that are not set are ignored.
 
-        :param gid: _description_, defaults to None
+        :param gid: Group id, defaults to None
         :type gid: int | None, optional
         :param members: List of group members, defaults to None
-        :type members: list[LDAPUser  |  LDAPGroup  |  str] | None, optional
+        :type members: list[GroupMemberField] | None, optional
         :param password: Group password, defaults to None
         :type password: str | None, optional
         :param description: Description, defaults to None
@@ -1125,20 +1230,20 @@ class LDAPGroup(LDAPObject[LDAPHost, LDAP]):
         self,
         *,
         gid: int | DeleteAttribute | None = None,
-        members: list[LDAPUser | LDAPGroup | str] | DeleteAttribute | None = None,
+        members: list[GroupMemberField] | DeleteAttribute | None = None,
         password: str | DeleteAttribute | None = None,
         description: str | DeleteAttribute | None = None,
     ) -> LDAPGroup:
         """
         Modify existing LDAP group.
 
-        Parameters that are not set are ignored. If needed, you can delete an
-        attribute by setting the value to :attr:`Delete`.
+        Implements :meth:`GenericGroup.modify`. Parameters that are not set are ignored.
+        If needed, you can delete an attribute by setting the value to :attr:`Delete`.
 
         :param gid: Group id, defaults to None
         :type gid: int | DeleteAttribute | None, optional
         :param members: List of group members, defaults to None
-        :type members: list[LDAPUser  |  LDAPGroup  |  str] | DeleteAttribute | None, optional
+        :type members: list[GroupMemberField] | DeleteAttribute | None, optional
         :param password: Group password, defaults to None
         :type password: str | DeleteAttribute | None, optional
         :param description: Description, defaults to None
@@ -1156,46 +1261,54 @@ class LDAPGroup(LDAPObject[LDAPHost, LDAP]):
         self._set(attrs)
         return self
 
-    def add_member(self, member: LDAPUser | LDAPGroup | str) -> LDAPGroup:
+    def add_member(self, member: GroupMemberField) -> LDAPGroup:
         """
         Add group member.
 
+        Implements :meth:`GenericGroup.add_member`.
+
         :param member: User or group (on rfc2307bis schema) to add as a member.
-        :type member: LDAPUser | LDAPGroup | str
+        :type member: GroupMemberField
         :return: Self.
         :rtype: LDAPGroup
         """
         return self.add_members([member])
 
-    def add_members(self, members: list[LDAPUser | LDAPGroup | str]) -> LDAPGroup:
+    def add_members(self, members: list[GroupMemberField]) -> LDAPGroup:
         """
         Add multiple group members.
 
+        Implements :meth:`GenericGroup.add_members`.
+
         :param members: Users or groups (on rfc2307bis schema) to add as members.
-        :type members: list[LDAPUser | LDAPGroup | str]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: LDAPGroup
         """
         self._modify(add={self.member_attr: self.__members(members)})
         return self
 
-    def remove_member(self, member: LDAPUser | LDAPGroup | str) -> LDAPGroup:
+    def remove_member(self, member: GroupMemberField) -> LDAPGroup:
         """
         Remove group member.
 
-        :param member: User or group (on rfc2307bis schema) to add as a member.
-        :type member: LDAPUser | LDAPGroup | str
+        Implements :meth:`GenericGroup.remove_member`.
+
+        :param member: User or group (on rfc2307bis schema) to remove from the group.
+        :type member: GroupMemberField
         :return: Self.
         :rtype: LDAPGroup
         """
         return self.remove_members([member])
 
-    def remove_members(self, members: list[LDAPUser | LDAPGroup | str]) -> LDAPGroup:
+    def remove_members(self, members: list[GroupMemberField]) -> LDAPGroup:
         """
         Remove multiple group members.
 
-        :param members: Users or groups (on rfc2307bis schema) to add as members.
-        :type members: list[LDAPUser | LDAPGroup | str]
+        Implements :meth:`GenericGroup.remove_members`.
+
+        :param members: Users or groups (on rfc2307bis schema) to remove from the group.
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: LDAPGroup
         """
@@ -1203,9 +1316,17 @@ class LDAPGroup(LDAPObject[LDAPHost, LDAP]):
         return self
 
 
-class LDAPNetgroup(Generic[HostType, LDAPRoleType, LDAPUserType], LDAPObject[HostType, LDAPRoleType]):
+class LDAPNetgroup(
+    Generic[HostType, LDAPRoleType, LDAPUserType],
+    LDAPObject[HostType, LDAPRoleType],
+    GenericNetgroup,
+):
     """
     LDAP netgroup management.
+
+    :class:`LDAPNetgroup` implements :class:`GenericNetgroup` for static typing and
+    provider-agnostic tests. The optional ``domain`` argument on membership methods is
+    LDAP-specific (NIS triple) and is not part of the generic API.
     """
 
     def __init__(self, role: LDAPRoleType, name: str, basedn: LDAPObject | str | None = "ou=netgroups") -> None:
@@ -1219,9 +1340,24 @@ class LDAPNetgroup(Generic[HostType, LDAPRoleType, LDAPUserType], LDAPObject[Hos
         """
         super().__init__(role, name, f"cn={name}", basedn, default_ou="netgroups")
 
+    @property
+    def name(self) -> str:
+        """
+        Netgroup name.
+
+        Implements :attr:`GenericNetgroup.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
     def add(self) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
         """
         Create new LDAP netgroup.
+
+        Implements :meth:`GenericNetgroup.add`.
 
         :return: Self.
         :rtype: LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]
@@ -1238,32 +1374,37 @@ class LDAPNetgroup(Generic[HostType, LDAPRoleType, LDAPUserType], LDAPObject[Hos
         self,
         *,
         host: str | None = None,
-        user: LDAPUser | str | None = None,
+        user: GenericUser | str | None = None,
         domain: str | None = None,
-        ng: LDAPNetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
         """
         Add netgroup member.
 
+        Implements :meth:`GenericNetgroup.add_member`.
+
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: LDAPUser | str | None, optional
-        :param domain: Domain, defaults to None
+        :type user: GenericUser | str | None, optional
+        :param domain: Domain (NIS triple field), defaults to None
         :type domain: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: LDAPNetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         :return: Self.
         :rtype: LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]
         """
         return self.add_members([LDAPNetgroupMember(host=host, user=user, domain=domain, ng=ng)])
 
-    def add_members(self, members: list[LDAPNetgroupMember]) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
+    def add_members(self, members: list[GenericNetgroupMember]) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
         """
         Add multiple netgroup members.
 
+        Implements :meth:`GenericNetgroup.add_members`. Use :class:`LDAPNetgroupMember` for
+        LDAP NIS triples with ``domain``.
+
         :param members: Netgroup members.
-        :type members: list[LDAPNetgroupMember]
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]
         """
@@ -1283,32 +1424,39 @@ class LDAPNetgroup(Generic[HostType, LDAPRoleType, LDAPUserType], LDAPObject[Hos
         self,
         *,
         host: str | None = None,
-        user: LDAPUser | str | None = None,
+        user: GenericUser | str | None = None,
         domain: str | None = None,
-        ng: LDAPNetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
         """
         Remove netgroup member.
 
+        Implements :meth:`GenericNetgroup.remove_member`.
+
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: LDAPUser | str | None, optional
-        :param domain: Domain, defaults to None
+        :type user: GenericUser | str | None, optional
+        :param domain: Domain (NIS triple field), defaults to None
         :type domain: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: LDAPNetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         :return: Self.
         :rtype: LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]
         """
         return self.remove_members([LDAPNetgroupMember(host=host, user=user, domain=domain, ng=ng)])
 
-    def remove_members(self, members: list[LDAPNetgroupMember]) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
+    def remove_members(
+        self, members: list[GenericNetgroupMember]
+    ) -> LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]:
         """
         Remove multiple netgroup members.
 
+        Implements :meth:`GenericNetgroup.remove_members`. Use :class:`LDAPNetgroupMember`
+        for LDAP NIS triples with ``domain``.
+
         :param members: Netgroup members.
-        :type members: list[LDAPNetgroupMember]
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: LDAPNetgroup[HostType, LDAPRoleType, LDAPUserType]
         """
@@ -1324,12 +1472,12 @@ class LDAPNetgroup(Generic[HostType, LDAPRoleType, LDAPUserType], LDAPObject[Hos
         self._modify(delete=attrs)
         return self
 
-    def __members(self, members: list[LDAPNetgroupMember]) -> tuple[list[str], list[str]]:
+    def __members(self, members: list[GenericNetgroupMember]) -> tuple[list[str], list[str]]:
         """
-        Split members into triples and netgroups
+        Split members into triples and netgroups.
 
         :param members: Netgroup members.
-        :type members: list[LDAPNetgroupMember]
+        :type members: list[GenericNetgroupMember]
         :return: (triples, netgroups)
         :rtype: tuple[list[str], list[str]]
         """
@@ -1356,19 +1504,19 @@ class LDAPNetgroupMember(Generic[LDAPUserType, LDAPNetgroupType], GenericNetgrou
         self,
         *,
         host: str | None = None,
-        user: LDAPUserType | str | None = None,
+        user: GenericUser | str | None = None,
         domain: str | None = None,
-        ng: LDAPNetgroupType | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> None:
         """
         :param host: Host, defaults to None
         :type host: str | None, optional
         :param user: User, defaults to None
-        :type user: LDAPUserType | str | None, optional
+        :type user: GenericUser | str | None, optional
         :param domain: Domain, defaults to None
         :type domain: str | None, optional
         :param ng: Netgroup, defaults to None
-        :type ng: LDAPNetgroupType | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
         """
         super().__init__(host=host, user=user, ng=ng)
 
@@ -1388,9 +1536,18 @@ class LDAPNetgroupMember(Generic[LDAPUserType, LDAPNetgroupType], GenericNetgrou
         return f"({_value(self.host)}, {_value(self.user)}, {_value(self.domain, '')})"
 
 
-class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType], LDAPObject[HostType, LDAPRoleType]):
+class LDAPSudoRule(
+    Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
+    LDAPObject[HostType, LDAPRoleType],
+    GenericSudoRule,
+):
     """
     LDAP sudo rule management.
+
+    :class:`LDAPSudoRule` implements :class:`GenericSudoRule` for static typing and
+    provider-agnostic tests. ``int`` values (SID fragments as ``#N``), ``notbefore`` /
+    ``notafter``, and :class:`DeleteAttribute` on :meth:`modify` are in addition to the
+    generic API.
     """
 
     def __init__(
@@ -1421,17 +1578,28 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
         self.group_cls: type[LDAPGroupType] = group_cls
         """Group class."""
 
+    @property
+    def name(self) -> str:
+        """
+        Sudo rule name.
+
+        Implements :attr:`GenericSudoRule.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
     def add(
         self,
         *,
-        user: int | str | LDAPUserType | LDAPGroupType | list[int | str | LDAPUserType | LDAPGroupType] | None = None,
-        host: str | list[str] | None = None,
-        command: str | list[str] | None = None,
+        user: SudoRuleUserField | int | list[SudoRuleUserField | int] | None = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: (
-            int | str | LDAPUserType | LDAPGroupType | list[int | str | LDAPUserType | LDAPGroupType] | None
-        ) = None,
-        runasgroup: int | str | LDAPGroupType | list[int | str | LDAPGroupType] | None = None,
+        runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | None = None,
+        runasgroup: SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | None = None,
         notbefore: str | list[str] | None = None,
         notafter: str | list[str] | None = None,
         order: int | list[int] | None = None,
@@ -1439,6 +1607,9 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
     ) -> LDAPSudoRule:
         """
         Create new sudo rule.
+
+        Implements :meth:`GenericSudoRule.add`. ``notbefore`` and ``notafter`` are
+        LDAP-specific and are not part of the generic API.
 
         :param user: sudoUser attribute, defaults to None
         :type user: int | str | LDAPUserType | LDAPGroupType | list[int | str | LDAPUserType | LDAPGroupType], optional
@@ -1489,28 +1660,14 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
     def modify(
         self,
         *,
-        user: (
-            int
-            | str
-            | LDAPUserType
-            | LDAPGroupType
-            | list[int | str | LDAPUserType | LDAPGroupType]
-            | DeleteAttribute
-            | None
-        ) = None,
-        host: str | list[str] | DeleteAttribute | None = None,
-        command: str | list[str] | DeleteAttribute | None = None,
+        user: SudoRuleUserField | int | list[SudoRuleUserField | int] | DeleteAttribute | None = None,
+        host: SudoRuleHostField | DeleteAttribute | None = None,
+        command: SudoRuleCommandField | DeleteAttribute | None = None,
         option: str | list[str] | DeleteAttribute | None = None,
-        runasuser: (
-            int
-            | str
-            | LDAPUserType
-            | LDAPGroupType
-            | list[int | str | LDAPUserType | LDAPGroupType]
-            | DeleteAttribute
-            | None
+        runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | DeleteAttribute | None = None,
+        runasgroup: (
+            SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | DeleteAttribute | None
         ) = None,
-        runasgroup: int | str | LDAPGroupType | list[int | str | LDAPGroupType] | DeleteAttribute | None = None,
         notbefore: str | list[str] | DeleteAttribute | None = None,
         notafter: str | list[str] | DeleteAttribute | None = None,
         order: int | list[int] | DeleteAttribute | None = None,
@@ -1519,8 +1676,8 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
         """
         Modify existing sudo rule.
 
-        Parameters that are not set are ignored. If needed, you can delete an
-        attribute by setting the value to :attr:`Delete`.
+        Implements :meth:`GenericSudoRule.modify`. Parameters that are not set are ignored.
+        If needed, you can delete an attribute by setting the value to :attr:`Delete`.
 
         :param user: sudoUser attribute, defaults to None
         :type user: int | str | LDAPUserType | LDAPGroupType | list[int | str | LDAPUserType | LDAPGroupType]
@@ -1531,7 +1688,7 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
         :type command: str | list[str] | DeleteAttribute | None, optional
         :param option: sudoOption attribute, defaults to None
         :type option: str | list[str] | DeleteAttribute | None, optional
-        :param runasuser: sudoRunAsUsere attribute, defaults to None
+        :param runasuser: sudoRunAsUser attribute, defaults to None
         :type runasuser: int | str | LDAPUserType | LDAPGroupType | list[int | str | LDAPUserType | LDAPGroupType]
           | DeleteAttribute | None, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None
@@ -1568,23 +1725,12 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
         self._set(attrs)
         return self
 
-    def __sudo_user(
-        self,
-        sudo_user: (
-            None
-            | DeleteAttribute
-            | int
-            | str
-            | LDAPUserType
-            | LDAPGroupType
-            | list[int | str | LDAPUserType | LDAPGroupType]
-        ),
-    ) -> list[str] | DeleteAttribute | None:
-        def _get_value(value: int | str | LDAPUserType | LDAPGroupType):
-            if isinstance(value, self.user_cls):
+    def __sudo_user(self, sudo_user: _LDAPSudoUserInput) -> list[str] | DeleteAttribute | None:
+        def _get_value(value: _LDAPSudoUserAtom) -> str:
+            if isinstance(value, self.user_cls) or isinstance(value, GenericUser):
                 return value.name
 
-            if isinstance(value, self.group_cls):
+            if isinstance(value, self.group_cls) or isinstance(value, GenericGroup):
                 return "%" + value.name
 
             if isinstance(value, str):
@@ -1592,6 +1738,10 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
 
             if isinstance(value, int):
                 return "#" + str(value)
+
+            name = getattr(value, "name", None)
+            if isinstance(name, str):
+                return name
 
             raise ValueError(f"Unsupported type: {type(value)}")
 
@@ -1602,19 +1752,17 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
             return sudo_user
 
         if not isinstance(sudo_user, list):
-            return [_get_value(sudo_user)]
+            return [_get_value(cast(_LDAPSudoUserAtom, sudo_user))]
 
         out = []
         for value in sudo_user:
-            out.append(_get_value(value))
+            out.append(_get_value(cast(_LDAPSudoUserAtom, value)))
 
         return out
 
-    def __sudo_group(
-        self, sudo_group: None | DeleteAttribute | int | str | LDAPGroupType | list[int | str | LDAPGroupType]
-    ) -> list[str] | DeleteAttribute | None:
-        def _get_value(value: int | str | LDAPGroupType):
-            if isinstance(value, self.group_cls):
+    def __sudo_group(self, sudo_group: _LDAPSudoRunAsGroupInput) -> list[str] | DeleteAttribute | None:
+        def _get_value(value: _LDAPSudoGroupAtom) -> str:
+            if isinstance(value, self.group_cls) or isinstance(value, GenericGroup):
                 return value.name
 
             if isinstance(value, str):
@@ -1622,6 +1770,10 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
 
             if isinstance(value, int):
                 return "#" + str(value)
+
+            name = getattr(value, "name", None)
+            if isinstance(name, str):
+                return name
 
             raise ValueError(f"Unsupported type: {type(value)}")
 
@@ -1632,18 +1784,22 @@ class LDAPSudoRule(Generic[HostType, LDAPRoleType, LDAPUserType, LDAPGroupType],
             return sudo_group
 
         if not isinstance(sudo_group, list):
-            return [_get_value(sudo_group)]
+            return [_get_value(cast(_LDAPSudoGroupAtom, sudo_group))]
 
         out = []
         for value in sudo_group:
-            out.append(_get_value(value))
+            out.append(_get_value(cast(_LDAPSudoGroupAtom, value)))
 
         return out
 
 
-class LDAPAutomount(Generic[HostType, LDAPRoleType]):
+class LDAPAutomount(Generic[HostType, LDAPRoleType], GenericAutomount):
     """
     LDAP automount management.
+
+    :class:`LDAPAutomount` implements :class:`GenericAutomount` for static typing and
+    provider-agnostic tests. The optional ``basedn`` argument on :meth:`map` is
+    LDAP-specific and is not part of the generic API.
     """
 
     class Schema(Enum):
@@ -1669,26 +1825,33 @@ class LDAPAutomount(Generic[HostType, LDAPRoleType]):
         """
         Get automount map object.
 
+        Implements :meth:`GenericAutomount.map`; ``basedn`` selects the LDAP container
+        for the map (defaults to ``ou=autofs``).
+
         :param name: Automount map name.
         :type name: str
         :param basedn: Base dn, defaults to ``ou=autofs``
         :type basedn: LDAPObject | str | None, optional
         :return: New automount map object.
-        :rtype: LDAPAutomountMap[HostType, LDAPRoleType]:
+        :rtype: LDAPAutomountMap[HostType, LDAPRoleType]
         """
         return LDAPAutomountMap[HostType, LDAPRoleType](self.__role, name, basedn, schema=self.__schema)
 
-    def key(self, name: str, map: LDAPAutomountMap) -> LDAPAutomountKey[HostType, LDAPRoleType]:
+    def key(self, name: str, map: GenericAutomountMap) -> LDAPAutomountKey[HostType, LDAPRoleType]:
         """
         Get automount key object.
+
+        Implements :meth:`GenericAutomount.key`.
 
         :param name: Automount key name.
         :type name: str
         :param map: Automount map that is a parent to this key.
-        :type map: LDAPAutomountMap
+        :type map: GenericAutomountMap
         :return: New automount key object.
         :rtype: LDAPAutomountKey[HostType, LDAPRoleType]
         """
+        if not isinstance(map, LDAPAutomountMap):
+            raise TypeError("LDAP automount keys require an LDAP automount map parent map.")
         return LDAPAutomountKey[HostType, LDAPRoleType](self.__role, name, map, schema=self.__schema)
 
     def set_schema(self, schema: "LDAPAutomount.Schema"):
@@ -1701,9 +1864,13 @@ class LDAPAutomount(Generic[HostType, LDAPRoleType]):
         self.__schema = schema
 
 
-class LDAPAutomountMap(LDAPObject[HostType, LDAPRoleType]):
+class LDAPAutomountMap(LDAPObject[HostType, LDAPRoleType], GenericAutomountMap):
     """
     LDAP automount map management.
+
+    :class:`LDAPAutomountMap` implements :class:`GenericAutomountMap` for static typing
+    and provider-agnostic tests. The ``schema`` argument on construction is LDAP-specific
+    and is not part of the generic API.
     """
 
     def __init__(
@@ -1726,7 +1893,20 @@ class LDAPAutomountMap(LDAPObject[HostType, LDAPRoleType]):
         """
         self.__schema: LDAPAutomount.Schema = schema
         self.__attrs: dict[str, str] = self.__get_attrs_map(schema)
-        super().__init__(role, name, f'{self.__attrs["rdn"]}={name}', basedn, default_ou="autofs")
+        super().__init__(role, name, f"{self.__attrs['rdn']}={name}", basedn, default_ou="autofs")
+
+    @property
+    def name(self) -> str:
+        """
+        Automount map name.
+
+        Implements :attr:`GenericAutomountMap.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
 
     def __get_attrs_map(self, schema: LDAPAutomount.Schema) -> dict[str, str]:
         if schema == LDAPAutomount.Schema.RFC2307:
@@ -1756,6 +1936,8 @@ class LDAPAutomountMap(LDAPObject[HostType, LDAPRoleType]):
         """
         Create new LDAP automount map.
 
+        Implements :meth:`GenericAutomountMap.add`.
+
         :return: Self.
         :rtype: LDAPAutomountMap
         """
@@ -1774,17 +1956,23 @@ class LDAPAutomountMap(LDAPObject[HostType, LDAPRoleType]):
         """
         Get automount key object for this map.
 
+        Implements :meth:`GenericAutomountMap.key`.
+
         :param name: Automount key name.
         :type name: str
         :return: New automount key object.
-        :rtype: LDAPAutomountKey
+        :rtype: LDAPAutomountKey[HostType, LDAPRoleType]
         """
         return LDAPAutomountKey(self.role, name, self, schema=self.__schema)
 
 
-class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType]):
+class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType], GenericAutomountKey):
     """
     LDAP automount key management.
+
+    :class:`LDAPAutomountKey` implements :class:`GenericAutomountKey` for static typing
+    and provider-agnostic tests. The ``schema`` argument on construction is LDAP-specific
+    and is not part of the generic API.
     """
 
     def __init__(
@@ -1808,9 +1996,22 @@ class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType]):
         self.__schema: LDAPAutomount.Schema = schema
         self.__attrs: dict[str, str] = self.__get_attrs_map(schema)
 
-        super().__init__(role, name, f'{self.__attrs["rdn"]}={name}', map)
+        super().__init__(role, name, f"{self.__attrs['rdn']}={name}", map)
         self.map: LDAPAutomountMap = map
         self.info: str = ""
+
+    @property
+    def name(self) -> str:
+        """
+        Automount key name.
+
+        Implements :attr:`GenericAutomountKey.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
 
     def __get_attrs_map(self, schema: LDAPAutomount.Schema) -> dict[str, str]:
         if schema == LDAPAutomount.Schema.RFC2307:
@@ -1837,12 +2038,14 @@ class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType]):
         else:
             raise ValueError(f"Unknown schema: {schema}")
 
-    def add(self, *, info: str | NFSExport | LDAPAutomountMap) -> LDAPAutomountKey:
+    def add(self, *, info: str | NFSExport | GenericAutomountMap) -> LDAPAutomountKey:
         """
         Create new LDAP automount key.
 
+        Implements :meth:`GenericAutomountKey.add`.
+
         :param info: Automount information.
-        :type info: str | NFSExport | LDAPAutomountMap
+        :type info: str | NFSExport | GenericAutomountMap
         :return: Self.
         :rtype: LDAPAutomountKey
         """
@@ -1867,13 +2070,16 @@ class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType]):
     def modify(
         self,
         *,
-        info: str | NFSExport | LDAPAutomountMap | DeleteAttribute | None = None,
+        info: str | NFSExport | GenericAutomountMap | DeleteAttribute | None = None,
     ) -> LDAPAutomountKey:
         """
         Modify existing LDAP automount key.
 
+        Implements :meth:`GenericAutomountKey.modify`. :class:`DeleteAttribute` is
+        LDAP-specific and is not part of the generic API.
+
         :param info: Automount information, defaults to ``None``
-        :type info: str | NFSExport | LDAPAutomountMap | DeleteAttribute | None
+        :type info: str | NFSExport | GenericAutomountMap | DeleteAttribute | None
         :return: Self.
         :rtype: LDAPAutomountKey
         """
@@ -1910,11 +2116,11 @@ class LDAPAutomountKey(LDAPObject[HostType, LDAPRoleType]):
         """
         return self.dump()
 
-    def __get_info(self, info: str | NFSExport | LDAPAutomountMap | DeleteAttribute | None):
+    def __get_info(self, info: str | NFSExport | GenericAutomountMap | DeleteAttribute | None):
         if isinstance(info, NFSExport):
             return info.get()
 
-        if isinstance(info, LDAPAutomountMap):
+        if isinstance(info, GenericAutomountMap):
             return info.name
 
         return info

--- a/sssd_test_framework/roles/nfs.py
+++ b/sssd_test_framework/roles/nfs.py
@@ -78,7 +78,7 @@ class NFSExport(BaseObject[NFSHost, NFS]):
         self.fullpath: str = f"{self.role.exports_dir}/{self.path}"
         """Absolute path of the exported directory."""
 
-        self.exports_file = f'/etc/exports.d/{path.replace("/", "_")}.exports'
+        self.exports_file = f"/etc/exports.d/{path.replace('/', '_')}.exports"
         """NFS exports file that manages this directory."""
 
         self.opts: str = "rw,sync,no_root_squash"

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import configparser
+from datetime import datetime
 from typing import Any, TypeAlias
 
 import ldap.modlist
@@ -14,8 +15,36 @@ from ..hosts.samba import SambaHost
 from ..misc import attrs_parse, ip_to_ptr, ip_version, to_list_of_strings
 from ..utils.ldap import LDAPRecordAttributes
 from .base import BaseLinuxLDAPRole, BaseObject, DeleteAttribute
-from .generic import GenericPasswordPolicy
-from .ldap import LDAPAutomount, LDAPNetgroup, LDAPNetgroupMember, LDAPObject, LDAPOrganizationalUnit, LDAPSudoRule
+from .generic import (
+    GenericAutomount,
+    GenericAutomountMap,
+    GenericComputer,
+    GenericDNSServer,
+    GenericDNSZone,
+    GenericGPO,
+    GenericGroup,
+    GenericOrganizationalUnit,
+    GenericPasswordPolicy,
+    GenericSite,
+    GenericSudoRule,
+    GenericUser,
+    GroupMemberField,
+    SudoRuleCommandField,
+    SudoRuleHostField,
+    SudoRuleRunAsGroupField,
+    SudoRuleRunAsUserField,
+    SudoRuleUserField,
+)
+from .ldap import (
+    LDAPAutomount,
+    LDAPAutomountKey,
+    LDAPAutomountMap,
+    LDAPNetgroup,
+    LDAPNetgroupMember,
+    LDAPObject,
+    LDAPOrganizationalUnit,
+    LDAPSudoRule,
+)
 
 __all__ = [
     "Samba",
@@ -299,7 +328,7 @@ class Samba(BaseLinuxLDAPRole[SambaHost]):
         :param name: Computer name.
         :type name: str
         :return: New computer object.
-        :rtype: ADComputer
+        :rtype: SambaComputer
         """
         return SambaComputer(self, name)
 
@@ -455,8 +484,8 @@ class SambaObject(BaseObject):
     """
     Base class for Samba DC object management.
 
-    Provides shortcuts for command execution and implementation of :meth:`get`
-    and :meth:`delete` methods.
+    Provides shortcuts for command execution and implementation of :meth:`get`,
+    :meth:`get_attrs`, and :meth:`delete` methods.
     """
 
     def __init__(self, role: Samba, command: str, name: str) -> None:
@@ -525,7 +554,7 @@ class SambaObject(BaseObject):
         :param attrs: Attributes to modify.
         :type attrs: dict[str, Any  |  list[Any]  |  DeleteAttribute  |  None]
         """
-        obj = self.get()
+        obj = self.get_attrs()
 
         # Remove dn and distinguishedName attributes
         dn = obj.pop("dn")[0]
@@ -563,9 +592,9 @@ class SambaObject(BaseObject):
         """
         self._exec("delete")
 
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get_attrs(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
         """
-        Get Samba object attributes.
+        Get Samba object attributes from LDAP.
 
         :param attrs: If set, only requested attributes are returned, defaults to None
         :type attrs: list[str] | None, optional
@@ -609,7 +638,7 @@ class SambaObject(BaseObject):
         if self.__dn is not None:
             return self.__dn
 
-        obj = self.get(["dn"])
+        obj = self.get_attrs(["dn"])
         self.__dn = obj.pop("dn")[0]
         return self.__dn
 
@@ -621,7 +650,7 @@ class SambaObject(BaseObject):
         if self.__cn is not None:
             return self.__cn
 
-        obj = self.get(["cn"])
+        obj = self.get_attrs(["cn"])
         self.__cn = obj.pop("cn")[0]
         return self.__cn
 
@@ -633,14 +662,18 @@ class SambaObject(BaseObject):
         if self.__sid is not None:
             return self.__sid
 
-        obj = self.get(["objectSid"])
+        obj = self.get_attrs(["objectSid"])
         self.__sid = obj.pop("objectSid")[0]
         return self.__sid
 
 
-class SambaUser(SambaObject):
+class SambaUser(SambaObject, GenericUser):
     """
     Samba user management.
+
+    :class:`SambaUser` implements :class:`GenericUser` for static typing and
+    provider-agnostic tests. Samba-specific keyword arguments on :meth:`modify` are in
+    addition to the generic API.
     """
 
     def __init__(self, role: Samba, name: str) -> None:
@@ -652,12 +685,42 @@ class SambaUser(SambaObject):
         """
         super().__init__(role, "user", name)
 
+    @property
+    def name(self) -> str:
+        """
+        User name.
+
+        Implements :attr:`GenericUser.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get user attributes.
+
+        Implements :meth:`GenericUser.get`. Use :meth:`SambaObject.get_attrs` when a
+        non-optional attribute dictionary is required. LDAP ``opattrs`` is ignored.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericUser` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key.
+        :rtype: dict[str, list[str]] | None
+        """
+        _ = opattrs
+        return self.get_attrs(attrs)
+
     def add(
         self,
         *,
         uid: int | None = None,
         gid: int | None = None,
-        password: str | None = "Secret123",
+        password: str = "Secret123",
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
@@ -708,6 +771,7 @@ class SambaUser(SambaObject):
         *,
         uid: int | DeleteAttribute | None = None,
         gid: int | DeleteAttribute | None = None,
+        password: str | DeleteAttribute | None = None,
         home: str | DeleteAttribute | None = None,
         gecos: str | DeleteAttribute | None = None,
         shell: str | DeleteAttribute | None = None,
@@ -716,13 +780,15 @@ class SambaUser(SambaObject):
         """
         Modify existing Samba user.
 
-        Parameters that are not set are ignored. If needed, you can delete an
-        attribute by setting the value to :attr:`Delete`.
+        Implements :meth:`GenericUser.modify`. Parameters that are not set are ignored.
+        If needed, you can delete an attribute by setting the value to :attr:`Delete`.
 
         :param uid: User id, defaults to None
         :type uid: int | DeleteAttribute | None, optional
         :param gid: Primary group id, defaults to None
         :type gid: int | DeleteAttribute | None, optional
+        :param password: Password, defaults to None
+        :type password: str | DeleteAttribute | None, optional
         :param home: Home directory, defaults to None
         :type home: str | DeleteAttribute | None, optional
         :param gecos: GECOS, defaults to None
@@ -746,11 +812,53 @@ class SambaUser(SambaObject):
         attrs = {**unix_attrs, **samba_attrs}
 
         self._modify(attrs)
+
+        if password is not None and not isinstance(password, DeleteAttribute):
+            self.reset(str(password))
+
+        return self
+
+    def reset(self, password: str | None = "Secret123") -> SambaUser:
+        """
+        Reset user password.
+
+        Implements :meth:`GenericUser.reset`.
+
+        :param password: Password, defaults to 'Secret123'
+        :type password: str | None, optional
+        :return: Self.
+        :rtype: SambaUser
+        """
+        if password is None:
+            password = "Secret123"
+
+        self._exec("setpassword", [password])
+        return self
+
+    def expire(self, expiration: str | None = "19700101000000") -> SambaUser:
+        """
+        Set user password expiration date and time.
+
+        Implements :meth:`GenericUser.expire`.
+
+        :param expiration: Date and time for user password expiration, defaults to 19700101000000
+        :type expiration: str | None, optional
+        :return: Self.
+        :rtype: SambaUser
+        """
+        if expiration is None:
+            expiration = "19700101000000"
+
+        expire = datetime.strptime(expiration, "%Y%m%d%H%M%S")
+        filetime = str(int((expire.timestamp() + 11644473600) * 10_000_000))
+        self._modify({"accountExpires": filetime})
         return self
 
     def password_change_at_logon(self, **kwargs) -> SambaUser:
         """
         Force user to change password next logon.
+
+        Implements :meth:`GenericUser.password_change_at_logon`.
 
         :return: Self.
         :rtype: SambaUser
@@ -761,6 +869,8 @@ class SambaUser(SambaObject):
     def passkey_add(self, passkey_mapping: str) -> SambaUser:
         """
         Add passkey mapping to the user.
+
+        Implements :meth:`GenericUser.passkey_add`.
 
         :param passkey_mapping: Passkey mapping generated by ``sssctl passkey-register``
         :type passkey_mapping: str
@@ -775,19 +885,25 @@ class SambaUser(SambaObject):
         """
         Remove passkey mapping from the user.
 
+        Implements :meth:`GenericUser.passkey_remove`.
+
         :param passkey_mapping: Passkey mapping generated by ``sssctl passkey-register``
         :type passkey_mapping: str
         :return: Self.
-        :rtype: SambaUser.
+        :rtype: SambaUser
         """
         attrs: LDAPRecordAttributes = {"altSecurityIdentities": passkey_mapping}
         self.role.ldap.modify(self.dn, delete=attrs)
         return self
 
 
-class SambaGroup(SambaObject):
+class SambaGroup(SambaObject, GenericGroup):
     """
     Samba group management.
+
+    :class:`SambaGroup` implements :class:`GenericGroup` for static typing and
+    provider-agnostic tests. Samba-specific keyword arguments on :meth:`add` are in
+    addition to the generic API.
     """
 
     def __init__(self, role: Samba, name: str) -> None:
@@ -799,6 +915,36 @@ class SambaGroup(SambaObject):
         """
         super().__init__(role, "group", name)
 
+    @property
+    def name(self) -> str:
+        """
+        Group name.
+
+        Implements :attr:`GenericGroup.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get group attributes.
+
+        Implements :meth:`GenericGroup.get`. Use :meth:`SambaObject.get_attrs` when a
+        non-optional attribute dictionary is required. LDAP ``opattrs`` is ignored.
+
+        :param attrs: If set, only requested attributes are returned, defaults to None
+        :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericGroup` API compatibility.
+        :type opattrs: bool, optional
+        :return: Dictionary with attribute name as a key.
+        :rtype: dict[str, list[str]] | None
+        """
+        _ = opattrs
+        return self.get_attrs(attrs)
+
     def add(
         self,
         *,
@@ -809,6 +955,8 @@ class SambaGroup(SambaObject):
     ) -> SambaGroup:
         """
         Create new Samba group.
+
+        Implements :meth:`GenericGroup.add`; ``scope`` and ``category`` are Samba-specific.
 
         :param gid: Group id, defaults to None
         :type gid: int | None, optional
@@ -846,15 +994,15 @@ class SambaGroup(SambaObject):
         """
         Modify existing Samba group.
 
-        Parameters that are not set are ignored. If needed, you can delete an
-        attribute by setting the value to :attr:`Delete`.
+        Implements :meth:`GenericGroup.modify`. Parameters that are not set are ignored.
+        If needed, you can delete an attribute by setting the value to :attr:`Delete`.
 
         :param gid: Group id, defaults to None
         :type gid: int | DeleteAttribute | None, optional
         :param description: Description, defaults to None
         :type description: str | DeleteAttribute | None, optional
         :return: Self.
-        :rtype: SambaUser
+        :rtype: SambaGroup
         """
         attrs: dict[str, Any] = {
             "gidNumber": gid,
@@ -864,59 +1012,70 @@ class SambaGroup(SambaObject):
         self._modify(attrs)
         return self
 
-    def add_member(self, member: SambaUser | SambaGroup) -> SambaGroup:
+    def add_member(self, member: GroupMemberField) -> SambaGroup:
         """
         Add group member.
 
+        Implements :meth:`GenericGroup.add_member`.
+
         :param member: User or group to add as a member.
-        :type member: SambaUser | SambaGroup
+        :type member: GroupMemberField
         :return: Self.
         :rtype: SambaGroup
         """
         return self.add_members([member])
 
-    def add_members(self, members: list[SambaUser | SambaGroup]) -> SambaGroup:
+    def add_members(self, members: list[GroupMemberField]) -> SambaGroup:
         """
         Add multiple group members.
 
+        Implements :meth:`GenericGroup.add_members`.
+
         :param members: List of users or groups to add as members.
-        :type members: list[SambaUser | SambaGroup]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: SambaGroup
         """
         self._exec("addmembers", self.__get_member_args(members))
         return self
 
-    def remove_member(self, member: SambaUser | SambaGroup) -> SambaGroup:
+    def remove_member(self, member: GroupMemberField) -> SambaGroup:
         """
         Remove group member.
 
+        Implements :meth:`GenericGroup.remove_member`.
+
         :param member: User or group to remove from the group.
-        :type member: SambaUser | SambaGroup
+        :type member: GroupMemberField
         :return: Self.
         :rtype: SambaGroup
         """
         return self.remove_members([member])
 
-    def remove_members(self, members: list[SambaUser | SambaGroup]) -> SambaGroup:
+    def remove_members(self, members: list[GroupMemberField]) -> SambaGroup:
         """
         Remove multiple group members.
 
+        Implements :meth:`GenericGroup.remove_members`.
+
         :param members: List of users or groups to remove from the group.
-        :type members: list[SambaUser | SambaGroup]
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: SambaGroup
         """
         self._exec("removemembers", self.__get_member_args(members))
         return self
 
-    def __get_member_args(self, members: list[SambaUser | SambaGroup]) -> list[str]:
-        return [",".join([x.name for x in members])]
+    def __get_member_args(self, members: list[GroupMemberField]) -> list[str]:
+        return [",".join([x if isinstance(x, str) else x.name for x in members])]
 
 
-class SambaComputer(SambaObject):
+class SambaComputer(SambaObject, GenericComputer):
     """
-    AD computer management.
+    Samba computer management.
+
+    :class:`SambaComputer` implements :class:`GenericComputer` for static typing and
+    provider-agnostic tests.
     """
 
     def __init__(self, role: Samba, name: str) -> None:
@@ -928,9 +1087,24 @@ class SambaComputer(SambaObject):
         """
         super().__init__(role, "computer", name)
 
+    @property
+    def name(self) -> str:
+        """
+        Computer name.
+
+        Implements :attr:`GenericComputer.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
     def move(self, target: str) -> SambaComputer:
         """
         Move a computer object.
+
+        Implements :meth:`GenericComputer.move`.
 
         :param target: Target path.
         :type target: str
@@ -942,9 +1116,11 @@ class SambaComputer(SambaObject):
         return self
 
 
-class SambaSite(SambaObject):
+class SambaSite(SambaObject, GenericSite):
     """
-    AD Sites management.
+    Samba site management.
+
+    :class:`SambaSite` implements :class:`GenericSite` for static typing and provider-agnostic tests.
     """
 
     def __init__(self, role: Samba, name: str) -> None:
@@ -956,9 +1132,24 @@ class SambaSite(SambaObject):
         """
         super().__init__(role, "sites", name)
 
+    @property
+    def name(self) -> str:
+        """
+        Site name.
+
+        Implements :attr:`GenericSite.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
     def add(self) -> SambaSite:
         """
         Create new Samba site.
+
+        Implements :meth:`GenericSite.add`.
 
         :return: Self.
         :rtype: SambaSite
@@ -968,15 +1159,19 @@ class SambaSite(SambaObject):
         return self
 
 
-class SambaGPO(SambaObject):
+class SambaGPO(SambaObject, GenericGPO):
     """
-    Group policy object management.
+    Samba group policy object management.
+
+    :class:`SambaGPO` implements :class:`GenericGPO` for static typing and provider-agnostic tests.
     """
 
     def __init__(self, role: Samba, name: str) -> None:
         """
-        :param name: GPO name, defaults to 'Domain Test Policy'
-        :type name: str, optional
+        :param role: Samba role object.
+        :type role: Samba
+        :param name: GPO display name.
+        :type name: str
         """
         super().__init__(role, "gpo", name)
 
@@ -990,11 +1185,43 @@ class SambaGPO(SambaObject):
         self.credentials: str = f" --username={self.role.host.adminuser} --password={self.role.host.adminpw}"
         """Credentials to manage GPOs."""
 
+    @property
+    def name(self) -> str:
+        """
+        GPO display name.
+
+        Implements :attr:`GenericGPO.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def get(self, key: str) -> str | None:
+        """
+        Get GPO attribute value.
+
+        Implements :meth:`GenericGPO.get`.
+
+        :param key: LDAP attribute name.
+        :type key: str
+        :return: Attribute value.
+        :rtype: str | None
+        """
+        obj = self.get_attrs([key])
+        values = obj.get(key)
+        if values:
+            return values[0]
+        return None
+
     def add(self) -> SambaGPO:
         """
         Add a group policy object.
 
-        :return: Samba group policy object
+        Implements :meth:`GenericGPO.add`.
+
+        :return: Self.
         :rtype: SambaGPO
         """
         self.host.conn.run(f'samba-tool gpo create "{self.name}" {self.credentials}')
@@ -1004,6 +1231,8 @@ class SambaGPO(SambaObject):
     def delete(self) -> None:
         """
         Delete group policy object.
+
+        Implements :meth:`GenericGPO.delete`.
         """
         self.role.host.conn.run(f'samba-tool gpo del "{self.cn}" {self.credentials}')
 
@@ -1015,6 +1244,8 @@ class SambaGPO(SambaObject):
     ) -> SambaGPO:
         """
         Link the group policy to the target object inside the directory, a site, domain or an ou.
+
+        Implements :meth:`GenericGPO.link`.
 
         :param target: Group policy target, defaults to 'Default-First-Site-Name'
         :type target: str, optional
@@ -1044,20 +1275,29 @@ class SambaGPO(SambaObject):
 
         return self
 
-    def unlink(self) -> SambaGPO:
+    def unlink(self) -> None:
         """
         Unlink the group policy from the target.
 
-        :return: Samba group policy object
-        :rtype: SambaGPO
+        Implements :meth:`GenericGPO.unlink`.
         """
         self.host.conn.run(f'samba-tool gpo dellink "{self.target}" "{self.cn}" {self.credentials}')
 
-        return self
+    def permissions(self, target: str, permission_level: str, target_type: str | None = "Group") -> SambaGPO:
+        """
+        Configure GPO permissions.
 
-    def policy(self, logon_rights: dict[str, list[SambaObject]], cfg: dict[str, Any] | None = None) -> SambaGPO:
+        Implements :meth:`GenericGPO.permissions`.
+
+        :raises NotImplementedError: Samba GPO permission management is not implemented.
+        """
+        raise NotImplementedError("Samba GPO permissions are not supported by the test framework.")
+
+    def policy(self, logon_rights: dict[str, list[Any]], cfg: dict[str, Any] | None = None) -> SambaGPO:
         """
         Group policy configuration.
+
+        Implements :meth:`GenericGPO.policy`.
 
         This method does the remaining configuration of the group policy. It updates
         'GptTmpl.inf' with security logon right keys with the SIDs of users and groups
@@ -1074,18 +1314,14 @@ class SambaGPO(SambaObject):
         processed by the client.
 
         :param logon_rights: List of logon rights.
-        :type logon_rights: dict[str, list[SambaObject]]
+        :type logon_rights: dict[str, list[Any]]
         :param cfg: Extra configuration for GptTmpl.inf file, defaults to None
         :type cfg: dict[str, Any] | None, optional
         :return: Samba Group policy object
         :rtype: SambaGPO
         """
         _path: str = (
-            f"/var/lib/samba/sysvol/"
-            f"{self.role.domain}/"
-            f"Policies/{self.cn}"
-            f"/MACHINE/Microsoft/Windows "
-            f"NT/SecEdit/"
+            f"/var/lib/samba/sysvol/{self.role.domain}/Policies/{self.cn}/MACHINE/Microsoft/Windows NT/SecEdit/"
         )
         _full_path: str = f"{_path}GptTmpl.inf"
 
@@ -1148,13 +1384,17 @@ class SambaGPO(SambaObject):
 
 class SambaPasswordPolicy(GenericPasswordPolicy):
     """
-    Password policy management.
+    Samba domain password policy management.
+
+    :class:`SambaPasswordPolicy` implements :class:`GenericPasswordPolicy` for static
+    typing and provider-agnostic tests. Settings apply via ``samba-tool domain
+    passwordsettings``.
     """
 
-    def __init__(self, role: Samba):
+    def __init__(self, role: Samba) -> None:
         """
-        :param role: Samba host object.
-        :type role: SambaHost
+        :param role: Samba role object.
+        :type role: Samba
         """
         super().__init__(role)
 
@@ -1169,9 +1409,11 @@ class SambaPasswordPolicy(GenericPasswordPolicy):
         """
         Enable or disable password complexity.
 
+        Implements :meth:`GenericPasswordPolicy.complexity`.
+
         :param enable: Enable or disable password complexity.
         :type enable: bool
-        :return: SambaPasswordPolicy object.
+        :return: Self.
         :rtype: SambaPasswordPolicy
         """
         complexity: str = "on" if enable else "off"
@@ -1188,11 +1430,13 @@ class SambaPasswordPolicy(GenericPasswordPolicy):
         """
         Set lockout duration and login attempts.
 
+        Implements :meth:`GenericPasswordPolicy.lockout`.
+
         :param duration: Duration of lockout in seconds, converted to minutes.
         :type duration: int
         :param attempts: Number of login attempts.
         :type attempts: int
-        :return: SambaPasswordPolicy object.
+        :return: Self.
         :rtype: SambaPasswordPolicy
         """
         minutes = divmod(duration, 60)[0]
@@ -1206,15 +1450,18 @@ class SambaPasswordPolicy(GenericPasswordPolicy):
         return self
 
 
-class SambaDNSServer(BaseObject[SambaHost, Samba]):
+class SambaDNSServer(GenericDNSServer):
     """
-    DNS management utilities.
+    Samba DNS server management.
+
+    :class:`SambaDNSServer` implements :class:`GenericDNSServer` for static typing and
+    provider-agnostic tests.
     """
 
-    def __init__(self, role: Samba):
+    def __init__(self, role: Samba) -> None:
         """
-        :param role: Samba host object.
-        :type role: SambaHost
+        :param role: Samba role object.
+        :type role: Samba
         """
         super().__init__(role)
 
@@ -1234,31 +1481,32 @@ class SambaDNSServer(BaseObject[SambaHost, Samba]):
 
     def zone(self, name: str) -> SambaDNSZone:
         """
-        Get SambaDNSZone object.
+        Get DNS zone object.
+
+        Implements :meth:`GenericDNSServer.zone`.
 
         :param name: Zone name.
         :type name: str
-        :return: SambaDNSZone object.
+        :return: DNS zone object.
         :rtype: SambaDNSZone
         """
         return SambaDNSZone(self.role, name)
 
-    def get_forwarders(self) -> list[str] | None:
+    def get_forwarders(self) -> list[str]:
         """
         Get DNS global forwarders.
 
-        Global forwarders are configured in /etc/smb.conf
+        Global forwarders are configured in ``/etc/samba/smb.conf``.
 
-        :return: DNS global forwarders.
+        :return: List of forwarder IP addresses (empty if none are configured).
         :rtype: list[str]
         """
         result = [line.strip() for line in self.host.fs.read(self.smb_conf).split("\n")]
-        if result is not None and isinstance(result, list):
-            for i in result:
-                if "dns forwarder" in i:
-                    # The additional split is to support more than one server
-                    return i.split("=")[1].strip().split(" ")
-        return None
+        for i in result:
+            if "dns forwarder" in i:
+                # The additional split is to support more than one server
+                return i.split("=")[1].strip().split(" ")
+        return []
 
     def add_forwarder(self, ip_address: str) -> SambaDNSServer:
         """
@@ -1312,15 +1560,18 @@ class SambaDNSServer(BaseObject[SambaHost, Samba]):
         return result
 
 
-class SambaDNSZone(SambaDNSServer):
+class SambaDNSZone(SambaDNSServer, GenericDNSZone):
     """
-    DNS zone management.
+    Samba DNS zone management.
+
+    :class:`SambaDNSZone` implements :class:`GenericDNSZone` for static typing and
+    provider-agnostic tests.
     """
 
-    def __init__(self, role: Samba, name: str):
+    def __init__(self, role: Samba, name: str) -> None:
         """
-        :param role: Samba host object.
-        :type role: SambaHost
+        :param role: Samba role object.
+        :type role: Samba
         :param name: DNS zone name.
         :type name: str
         """
@@ -1333,8 +1584,10 @@ class SambaDNSZone(SambaDNSServer):
         """
         Create new zone.
 
-        :return: SambaDNSServer object.
-        :rtype: SambaDNSServer
+        Implements :meth:`GenericDNSZone.create`.
+
+        :return: Self.
+        :rtype: SambaDNSZone
         """
         self.host.conn.run(f"samba-tool dns zonecreate {self.server} {self.zone_name} {self.credentials}")
         return self
@@ -1342,21 +1595,25 @@ class SambaDNSZone(SambaDNSServer):
     def delete(self) -> None:
         """
         Delete zone.
+
+        Implements :meth:`GenericDNSZone.delete`.
         """
         self.host.conn.run(f"samba-tool dns zonedelete {self.server} {self.zone_name} {self.credentials}")
 
-    def add_record(self, name: str, data: str) -> SambaDNSZone:
+    def add_record(self, name: str, data: str | int) -> SambaDNSZone:
         """
         Add DNS record.
+
+        Implements :meth:`GenericDNSZone.add_record`.
 
         If ``data`` is a str, a forward record will be added.
         If an integer a reverse record will be added.
 
         :param name: Record name.
-        :type name: str | int
+        :type name: str
         :param data: Record data.
-        :type data: str
-        :return: SambaDNSZone object.
+        :type data: str | int
+        :return: Self.
         :rtype: SambaDNSZone
         """
         args = ""
@@ -1377,6 +1634,8 @@ class SambaDNSZone(SambaDNSServer):
     def delete_record(self, name: str) -> None:
         """
         Delete DNS record, both forward and reverse records are deleted.
+
+        Implements :meth:`GenericDNSZone.delete_record`.
 
         :param name: Name of the record.
         :type name: str
@@ -1413,9 +1672,11 @@ class SambaDNSZone(SambaDNSServer):
 
     def print(self) -> str:
         """
-        Prints all dns records in a zone as text.
+        Print all DNS records in a zone as text.
 
-        :return: Print zone data.
+        Implements :meth:`GenericDNSZone.print`.
+
+        :return: Zone data as text.
         :rtype: str
         """
         result = self.host.conn.run(
@@ -1425,8 +1686,186 @@ class SambaDNSZone(SambaDNSServer):
         return result
 
 
-SambaOrganizationalUnit: TypeAlias = LDAPOrganizationalUnit[SambaHost, Samba]
-SambaAutomount: TypeAlias = LDAPAutomount[SambaHost, Samba]
-SambaSudoRule: TypeAlias = LDAPSudoRule[SambaHost, Samba, SambaUser, SambaGroup]
+class SambaOrganizationalUnit(LDAPOrganizationalUnit[SambaHost, Samba], GenericOrganizationalUnit):
+    """
+    Samba organizational unit management.
+
+    :class:`SambaOrganizationalUnit` implements :class:`GenericOrganizationalUnit` for static
+    typing and provider-agnostic tests.
+    """
+
+    @property
+    def name(self) -> str:
+        """
+        OU name.
+
+        Implements :attr:`GenericOrganizationalUnit.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def add(self, name: str | None = None) -> SambaOrganizationalUnit:
+        """
+        Create new Samba organizational unit.
+
+        Implements :meth:`GenericOrganizationalUnit.add`. The optional ``name`` argument
+        is accepted for API compatibility; the OU name is taken from :meth:`Samba.ou`.
+
+        :param name: Unused; OU name is set when the object is created.
+        :type name: str | None
+        :return: Self.
+        :rtype: SambaOrganizationalUnit
+        """
+        _ = name
+        super().add()
+        return self
+
+
+class SambaAutomount(LDAPAutomount[SambaHost, Samba], GenericAutomount):
+    """
+    Samba automount management.
+
+    :class:`SambaAutomount` implements :class:`GenericAutomount` for static typing and
+    provider-agnostic tests. The optional ``basedn`` argument on :meth:`map` is
+    Samba-specific and is not part of the generic API.
+    """
+
+    def map(self, name: str, basedn: LDAPObject | str | None = "ou=autofs") -> LDAPAutomountMap[SambaHost, Samba]:
+        """
+        Get automount map object.
+
+        Implements :meth:`GenericAutomount.map`; ``basedn`` selects the LDAP container
+        for the map (defaults to ``ou=autofs``).
+
+        :param name: Automount map name.
+        :type name: str
+        :param basedn: Base dn, defaults to ``ou=autofs``
+        :type basedn: LDAPObject | str | None, optional
+        :return: New automount map object.
+        :rtype: LDAPAutomountMap[SambaHost, Samba]
+        """
+        return super().map(name, basedn)
+
+    def key(self, name: str, map: GenericAutomountMap) -> LDAPAutomountKey[SambaHost, Samba]:
+        """
+        Get automount key object.
+
+        Implements :meth:`GenericAutomount.key`.
+
+        :param name: Automount key name.
+        :type name: str
+        :param map: Automount map that is a parent to this key.
+        :type map: GenericAutomountMap
+        :return: New automount key object.
+        :rtype: LDAPAutomountKey[SambaHost, Samba]
+        """
+        if not isinstance(map, LDAPAutomountMap):
+            raise TypeError("Samba automount keys require an LDAP automount map parent map.")
+        return super().key(name, map)
+
+
+class SambaSudoRule(LDAPSudoRule[SambaHost, Samba, SambaUser, SambaGroup], GenericSudoRule):
+    """
+    Samba sudo rule management.
+
+    :class:`SambaSudoRule` implements :class:`GenericSudoRule` for static typing and
+    provider-agnostic tests. ``int`` values (SID fragments as ``#N``), ``notbefore`` /
+    ``notafter``, and :class:`DeleteAttribute` on :meth:`modify` are in addition to the
+    generic API.
+    """
+
+    @property
+    def name(self) -> str:
+        """
+        Sudo rule name.
+
+        Implements :attr:`GenericSudoRule.name`.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def add(
+        self,
+        *,
+        user: SudoRuleUserField | int | list[SudoRuleUserField | int] | None = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
+        option: str | list[str] | None = None,
+        runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | None = None,
+        runasgroup: SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | None = None,
+        notbefore: str | list[str] | None = None,
+        notafter: str | list[str] | None = None,
+        order: int | list[int] | None = None,
+        nopasswd: bool | None = None,
+    ) -> SambaSudoRule:
+        """
+        Create new sudo rule.
+
+        Implements :meth:`GenericSudoRule.add`. ``notbefore`` and ``notafter`` are
+        LDAP-specific and are not part of the generic API.
+
+        :return: Self.
+        :rtype: SambaSudoRule
+        """
+        super().add(
+            user=user,
+            host=host,
+            command=command,
+            option=option,
+            runasuser=runasuser,
+            runasgroup=runasgroup,
+            notbefore=notbefore,
+            notafter=notafter,
+            order=order,
+            nopasswd=nopasswd,
+        )
+        return self
+
+    def modify(
+        self,
+        *,
+        user: SudoRuleUserField | int | list[SudoRuleUserField | int] | DeleteAttribute | None = None,
+        host: SudoRuleHostField | DeleteAttribute | None = None,
+        command: SudoRuleCommandField | DeleteAttribute | None = None,
+        option: str | list[str] | DeleteAttribute | None = None,
+        runasuser: SudoRuleRunAsUserField | int | list[SudoRuleRunAsUserField | int] | DeleteAttribute | None = None,
+        runasgroup: (
+            SudoRuleRunAsGroupField | int | list[SudoRuleRunAsGroupField | int] | DeleteAttribute | None
+        ) = None,
+        notbefore: str | list[str] | DeleteAttribute | None = None,
+        notafter: str | list[str] | DeleteAttribute | None = None,
+        order: int | list[int] | DeleteAttribute | None = None,
+        nopasswd: bool | None = None,
+    ) -> SambaSudoRule:
+        """
+        Modify existing sudo rule.
+
+        Implements :meth:`GenericSudoRule.modify`. ``notbefore`` and ``notafter`` are
+        LDAP-specific and are not part of the generic API.
+
+        :return: Self.
+        :rtype: SambaSudoRule
+        """
+        super().modify(
+            user=user,
+            host=host,
+            command=command,
+            option=option,
+            runasuser=runasuser,
+            runasgroup=runasgroup,
+            notbefore=notbefore,
+            notafter=notafter,
+            order=order,
+            nopasswd=nopasswd,
+        )
+        return self
+
+
 SambaNetgroup: TypeAlias = LDAPNetgroup[SambaHost, Samba, SambaUser]
 SambaNetgroupMember: TypeAlias = LDAPNetgroupMember[SambaUser, SambaNetgroup]

--- a/sssd_test_framework/utils/automount.py
+++ b/sssd_test_framework/utils/automount.py
@@ -156,9 +156,9 @@ class AutomountUtils(MultihostUtility[MultihostHost]):
 
         def parse_result(lines: list[str]) -> dict[str, dict[str, str | list[str]]]:
             mountpoints: dict[str, dict[str, str | list[str]]] = {}
-            for i, l in enumerate(lines):
-                if l.startswith("Mount point: "):
-                    point = l.replace("Mount point: ", "").strip()
+            for i, line in enumerate(lines):
+                if line.startswith("Mount point: "):
+                    point = line.replace("Mount point: ", "").strip()
                     for k, l2 in enumerate(lines[i + 1 :], i + 1):
                         if l2.startswith("Mount point: "):
                             break

--- a/sssd_test_framework/utils/chrony.py
+++ b/sssd_test_framework/utils/chrony.py
@@ -112,7 +112,7 @@ class ChronyUtils(MultihostUtility[MultihostHost]):
             yield
         finally:
             self.host.conn.run(
-                f"chronyc -a -m 'settime {saved_time} + 10 seconds'" " 'makestep' 'manual reset' 'online' 2>&1",
+                f"chronyc -a -m 'settime {saved_time} + 10 seconds' 'makestep' 'manual reset' 'online' 2>&1",
                 raise_on_error=False,
             )
             self.host.conn.run(

--- a/sssd_test_framework/utils/dbus/types.py
+++ b/sssd_test_framework/utils/dbus/types.py
@@ -792,7 +792,7 @@ class DBUSSignatureReader:
                 if suffix is not None:
                     if not reminder.text.startswith(suffix):
                         raise ValueError(
-                            f"Found the prefix '{prefix}' but no suffix " f"'{suffix}' in the signature '{signature}'"
+                            f"Found the prefix '{prefix}' but no suffix '{suffix}' in the signature '{signature}'"
                         )
 
                     reminder.text = reminder.text.removeprefix(suffix)

--- a/sssd_test_framework/utils/local_users.py
+++ b/sssd_test_framework/utils/local_users.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Literal
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal
 
 import jc
 from pytest_mh import MultihostHost, MultihostUtility
@@ -11,7 +12,22 @@ from pytest_mh.cli import CLIBuilder, CLIBuilderArgs
 from pytest_mh.conn import ProcessLogLevel
 from pytest_mh.utils.fs import LinuxFileSystem
 
-from ..roles.generic import GenericNetgroupMember
+from ..roles.generic import (
+    GenericGroup,
+    GenericNetgroup,
+    GenericNetgroupMember,
+    GenericSudoRule,
+    GenericUser,
+    GroupMemberField,
+    SudoRuleCommandField,
+    SudoRuleHostField,
+    SudoRuleRunAsGroupField,
+    SudoRuleRunAsUserField,
+    SudoRuleUserField,
+)
+
+if TYPE_CHECKING:
+    from ..roles.client import Client
 
 __all__ = [
     "LocalGroup",
@@ -38,13 +54,16 @@ class LocalUsersUtils(MultihostUtility[MultihostHost]):
         All changes are automatically reverted when a test is finished.
     """
 
-    def __init__(self, host: MultihostHost, fs: LinuxFileSystem) -> None:
+    def __init__(self, host: MultihostHost, fs: LinuxFileSystem, client: Client | None = None) -> None:
         """
         :param host: Remote host instance.
         :type host: MultihostHost
+        :param client: Client role that owns this utility.
+        :type client: Client | None
         """
         super().__init__(host)
 
+        self._client: Client | None = client
         self.cli: CLIBuilder = host.cli
         self.fs: LinuxFileSystem = fs
         self._users: list[str] = []
@@ -246,9 +265,12 @@ class LocalUsersUtils(MultihostUtility[MultihostHost]):
         return LocalSudoRule(self, name)
 
 
-class LocalUser(object):
+class LocalUser(GenericUser):
     """
     Management of local users.
+
+    :class:`LocalUser` is a :class:`GenericUser` for static typing; passkey-related
+    methods are not supported on local ``/etc/passwd`` users.
     """
 
     def __init__(self, util: LocalUsersUtils, name: str) -> None:
@@ -258,24 +280,32 @@ class LocalUser(object):
         :param name: User name.
         :type name: str
         """
-        self.util = util
-        self.name = name
+        if util._client is None:
+            raise RuntimeError("LocalUser requires LocalUsersUtils to be bound to a Client (client= in constructor).")
+        super().__init__(util._client)
+        self.util: LocalUsersUtils = util
+        self._name: str = name
 
-    def __str__(self):
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
         """
         Returns a string representation of the LocalUser.
         """
-        return self.name
+        return self._name
 
     def add(
         self,
         *,
         uid: int | None = None,
         gid: int | None = None,
-        password: str | None = "Secret123",
+        password: str = "Secret123",
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
+        email: str | None = None,
     ) -> LocalUser:
         """
         Create new local user.
@@ -284,7 +314,7 @@ class LocalUser(object):
         :type uid: int | None, optional
         :param gid: Primary group id, defaults to None.
         :type gid: int | None, optional
-        :param password: Password, defaults to 'Secret123'.
+        :param password: Password, defaults to 'Secret123' (use empty string to skip ``passwd``).
         :type password: str, optional
         :param home: Home directory, defaults to None.
         :type home: str | None, optional
@@ -292,14 +322,17 @@ class LocalUser(object):
         :type gecos: str | None, optional
         :param shell: Login shell, defaults to None.
         :type shell: str | None, optional
+        :param email: Not applied to local users (present for :class:`GenericUser` API compatibility).
+        :type email: str | None, optional
         :return: Self.
         :rtype: LocalUser
         """
+        del email  # Local /etc/passwd user management does not set a mail attribute here.
         if home is not None:
             self.util.fs.backup(home)
 
         args: CLIBuilderArgs = {
-            "name": (self.util.cli.option.POSITIONAL, self.name),
+            "name": (self.util.cli.option.POSITIONAL, self._name),
             "uid": (self.util.cli.option.VALUE, uid),
             "gid": (self.util.cli.option.VALUE, gid),
             "home": (self.util.cli.option.VALUE, home),
@@ -307,13 +340,13 @@ class LocalUser(object):
             "shell": (self.util.cli.option.VALUE, shell),
         }
 
-        passwd = f" && passwd --stdin '{self.name}'" if password else ""
-        self.util.logger.info(f'Creating local user "{self.name}" on {self.util.host.hostname}')
+        passwd = f" && passwd --stdin '{self._name}'" if password else ""
+        self.util.logger.info(f'Creating local user "{self._name}" on {self.util.host.hostname}')
         self.util.host.conn.run(
             self.util.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error
         )
 
-        self.util._users.append(self.name)
+        self.util._users.append(self._name)
         return self
 
     def modify(
@@ -325,6 +358,7 @@ class LocalUser(object):
         home: str | None = None,
         gecos: str | None = None,
         shell: str | None = None,
+        email: str | None = None,
     ) -> LocalUser:
         """
         Modify existing local user.
@@ -341,12 +375,15 @@ class LocalUser(object):
         :type gecos: str | None, optional
         :param shell: Login shell, defaults to None.
         :type shell: str | None, optional
+        :param email: Not applied to local users (present for :class:`GenericUser` API compatibility).
+        :type email: str | None, optional
         :return: Self.
         :rtype: LocalUser
         """
+        del email  # Local /etc/passwd user management does not set a mail attribute here.
 
         args: CLIBuilderArgs = {
-            "name": (self.util.cli.option.POSITIONAL, self.name),
+            "name": (self.util.cli.option.POSITIONAL, self._name),
             "uid": (self.util.cli.option.VALUE, uid),
             "gid": (self.util.cli.option.VALUE, gid),
             "home": (self.util.cli.option.VALUE, home),
@@ -354,34 +391,98 @@ class LocalUser(object):
             "shell": (self.util.cli.option.VALUE, shell),
         }
 
-        passwd = f" && passwd --stdin '{self.name}'" if password else ""
-        self.util.logger.info(f'Modifying local user "{self.name}" on {self.util.host.hostname}')
+        passwd = f" && passwd --stdin '{self._name}'" if password else ""
+        self.util.logger.info(f'Modifying local user "{self._name}" on {self.util.host.hostname}')
         self.util.host.conn.run(
             self.util.cli.command("usermod", args) + passwd, input=password, log_level=ProcessLogLevel.Error
         )
 
         return self
 
+    def reset(self, password: str | None = "Secret123") -> LocalUser:
+        """
+        Reset user password.
+
+        :param password: Password, defaults to 'Secret123'
+        :type password: str, optional
+        :return: Self.
+        :rtype: LocalUser
+        """
+        return self.modify(password=password)
+
+    def expire(self, expiration: str | None = "19700101000000") -> LocalUser:
+        """
+        Set user password expiration date and time (via ``chage -E``).
+
+        :param expiration: Date and time for user password expiration, defaults to 19700101000000
+        :type expiration: str | None, optional
+        :return: Self.
+        :rtype: LocalUser
+        """
+        exp = expiration if expiration is not None else "19700101000000"
+        end = datetime.strptime(exp, "%Y%m%d%H%M%S")
+        date_str = end.strftime("%Y-%m-%d")
+        self.util.logger.info(
+            f'Setting password expiration for local user "{self._name}" on {self.util.host.hostname}'
+        )
+        self.util.host.conn.run(f"chage -E '{date_str}' '{self._name}'", log_level=ProcessLogLevel.Error)
+        return self
+
+    def password_change_at_logon(self, **kwargs) -> LocalUser:
+        """
+        Force user to change password next logon (``chage -d 0`` and password reset).
+
+        :return: Self.
+        :rtype: LocalUser
+        """
+        if "password" not in kwargs:
+            raise TypeError("Missing argument 'password'!")
+        self.modify(password=kwargs["password"])
+        self.util.logger.info(
+            f'Requiring password change at next logon for local user "{self._name}" on {self.util.host.hostname}'
+        )
+        self.util.host.conn.run(f"chage -d 0 '{self._name}'", log_level=ProcessLogLevel.Error)
+        return self
+
+    def passkey_add(self, passkey_mapping: str) -> LocalUser:
+        """
+        Add passkey mapping to the user.
+
+        :raises NotImplementedError: Not supported for local users.
+        """
+        raise NotImplementedError("LocalUser does not support passkey_add; use a directory-backed user.")
+
+    def passkey_remove(self, passkey_mapping: str) -> LocalUser:
+        """
+        Remove passkey mapping from the user.
+
+        :raises NotImplementedError: Not supported for local users.
+        """
+        raise NotImplementedError("LocalUser does not support passkey_remove; use a directory-backed user.")
+
     def delete(self) -> None:
         """
         Delete the user.
         """
-        self.util.logger.info(f'Deleting local user "{self.name}" on {self.util.host.hostname}')
-        self.util.host.conn.run(f"userdel '{self.name}' --force --remove", log_level=ProcessLogLevel.Error)
-        self.util._users.remove(self.name)
+        self.util.logger.info(f'Deleting local user "{self._name}" on {self.util.host.hostname}')
+        self.util.host.conn.run(f"userdel '{self._name}' --force --remove", log_level=ProcessLogLevel.Error)
+        self.util._users.remove(self._name)
 
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get user attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None.
         :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericUser` API compatibility.
+        :type opattrs: bool, optional
         :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :rtype: dict[str, list[str]] | None
         """
-        self.util.logger.info(f'Fetching local user "{self.name}" on {self.util.host.hostname}')
+        _ = opattrs
+        self.util.logger.info(f'Fetching local user "{self._name}" on {self.util.host.hostname}')
         result = self.util.host.conn.exec(
-            ["getent", "passwd", self.name], raise_on_error=False, log_level=ProcessLogLevel.Error
+            ["getent", "passwd", self._name], raise_on_error=False, log_level=ProcessLogLevel.Error
         )
         if result.rc != 0:
             return {}
@@ -399,9 +500,13 @@ class LocalUser(object):
         return {k: [str(v)] for k, v in jcresult[0].items() if not attrs or k in attrs}
 
 
-class LocalGroup(object):
+class LocalGroup(GenericGroup):
     """
     Management of local groups.
+
+    :class:`LocalGroup` is a :class:`GenericGroup` for static typing. Membership
+    changes only accept :class:`LocalUser` and :class:`LocalGroup`; directory
+    principals are not valid members of ``/etc/group``.
     """
 
     def __init__(self, util: LocalUsersUtils, name: str) -> None:
@@ -411,36 +516,62 @@ class LocalGroup(object):
         :param name: Group name.
         :type name: str
         """
-        self.util = util
-        self.name = name
+        if util._client is None:
+            raise RuntimeError("LocalGroup requires LocalUsersUtils to be bound to a Client (client= in constructor).")
+        super().__init__(util._client)
+        self.util: LocalUsersUtils = util
+        self._name: str = name
 
-    def __str__(self):
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
         """
         Returns a string representation of the LocalGroup.
         """
-        return self.name
+        return self._name
+
+    @staticmethod
+    def _member_principal_name(member: GroupMemberField) -> str:
+        """
+        Resolve a member to a local ``passwd``/``group`` name.
+
+        :raises NotImplementedError: if ``member`` is not a local user or local group.
+        """
+        if isinstance(member, str):
+            return member
+        if isinstance(member, (LocalUser, LocalGroup)):
+            return member.name
+        raise NotImplementedError(
+            "LocalGroup membership only supports LocalUser and LocalGroup; use directory-specific APIs otherwise."
+        )
 
     def add(
         self,
         *,
         gid: int | None = None,
+        description: str | None = None,
     ) -> LocalGroup:
         """
         Create new local group.
 
         :param gid: Group id, defaults to None.
         :type gid: int | None, optional
+        :param description: Not stored for pure local groups (present for :class:`GenericGroup` API compatibility).
+        :type description: str | None, optional
         :return: Self.
         :rtype: LocalGroup
         """
+        del description  # No description field in /etc/group via this API.
         args: CLIBuilderArgs = {
-            "name": (self.util.cli.option.POSITIONAL, self.name),
+            "name": (self.util.cli.option.POSITIONAL, self._name),
             "gid": (self.util.cli.option.VALUE, gid),
         }
 
-        self.util.logger.info(f'Creating local group "{self.name}" on {self.util.host.hostname}')
+        self.util.logger.info(f'Creating local group "{self._name}" on {self.util.host.hostname}')
         self.util.host.conn.run(self.util.cli.command("groupadd", args), log_level=ProcessLogLevel.Silent)
-        self.util._groups.append(self.name)
+        self.util._groups.append(self._name)
 
         return self
 
@@ -448,6 +579,7 @@ class LocalGroup(object):
         self,
         *,
         gid: int | None = None,
+        description: str | None = None,
     ) -> LocalGroup:
         """
         Modify existing local group.
@@ -456,16 +588,19 @@ class LocalGroup(object):
 
         :param gid: Group id, defaults to None.
         :type gid: int | None, optional
+        :param description: Not stored for pure local groups (present for :class:`GenericGroup` API compatibility).
+        :type description: str | None, optional
         :return: Self.
         :rtype: LocalGroup
         """
+        del description  # No description field in /etc/group via this API.
 
         args: CLIBuilderArgs = {
-            "name": (self.util.cli.option.POSITIONAL, self.name),
+            "name": (self.util.cli.option.POSITIONAL, self._name),
             "gid": (self.util.cli.option.VALUE, gid),
         }
 
-        self.util.logger.info(f'Modifying local group "{self.name}" on {self.util.host.hostname}')
+        self.util.logger.info(f'Modifying local group "{self._name}" on {self.util.host.hostname}')
         self.util.host.conn.run(self.util.cli.command("groupmod", args), log_level=ProcessLogLevel.Error)
 
         return self
@@ -474,22 +609,25 @@ class LocalGroup(object):
         """
         Delete the group.
         """
-        self.util.logger.info(f'Deleting local group "{self.name}" on {self.util.host.hostname}')
-        self.util.host.conn.run(f"groupdel '{self.name}' -f", log_level=ProcessLogLevel.Error)
-        self.util._groups.remove(self.name)
+        self.util.logger.info(f'Deleting local group "{self._name}" on {self.util.host.hostname}')
+        self.util.host.conn.run(f"groupdel '{self._name}' -f", log_level=ProcessLogLevel.Error)
+        self.util._groups.remove(self._name)
 
-    def get(self, attrs: list[str] | None = None) -> dict[str, list[str]]:
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
         """
         Get group attributes.
 
         :param attrs: If set, only requested attributes are returned, defaults to None.
         :type attrs: list[str] | None, optional
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericGroup` API compatibility.
+        :type opattrs: bool, optional
         :return: Dictionary with attribute name as a key.
-        :rtype: dict[str, list[str]]
+        :rtype: dict[str, list[str]] | None
         """
-        self.util.logger.info(f'Fetching local group "{self.name}" on {self.util.host.hostname}')
+        _ = opattrs
+        self.util.logger.info(f'Fetching local group "{self._name}" on {self.util.host.hostname}')
         result = self.util.host.conn.exec(
-            ["getent", "group", self.name], raise_on_error=False, log_level=ProcessLogLevel.Silent
+            ["getent", "group", self._name], raise_on_error=False, log_level=ProcessLogLevel.Silent
         )
         if result.rc != 0:
             return {}
@@ -506,62 +644,66 @@ class LocalGroup(object):
 
         return {k: [str(v)] for k, v in jcresult[0].items() if not attrs or k in attrs}
 
-    def add_member(self, member: LocalUser) -> LocalGroup:
+    def add_member(self, member: GroupMemberField) -> LocalGroup:
         """
         Add group member.
 
         :param member: User or group to add as a member.
-        :type member: LocalUser
+        :type member: GroupMemberField
         :return: Self.
         :rtype: LocalGroup
         """
         return self.add_members([member])
 
-    def add_members(self, members: list[LocalUser]) -> LocalGroup:
+    def add_members(self, members: list[GroupMemberField]) -> LocalGroup:
         """
         Add multiple group members.
 
-        :param member: List of users or groups to add as members.
-        :type member: list[LocalUser]
+        :param members: List of users or groups to add as members.
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: LocalGroup
         """
-        self.util.logger.info(f'Adding members to group "{self.name}" on {self.util.host.hostname}')
+        self.util.logger.info(f'Adding members to group "{self._name}" on {self.util.host.hostname}')
 
         if not members:
             return self
 
-        cmd = "\n".join([f"groupmems --group '{self.name}' --add '{x.name}'" for x in members])
+        cmd = "\n".join(
+            [f"groupmems --group '{self._name}' --add '{self._member_principal_name(x)}'" for x in members]
+        )
         self.util.host.conn.run("set -ex\n" + cmd, log_level=ProcessLogLevel.Error)
 
         return self
 
-    def remove_member(self, member: LocalUser) -> LocalGroup:
+    def remove_member(self, member: GroupMemberField) -> LocalGroup:
         """
         Remove group member.
 
         :param member: User or group to remove from the group.
-        :type member: LocalUser
+        :type member: GroupMemberField
         :return: Self.
         :rtype: LocalGroup
         """
         return self.remove_members([member])
 
-    def remove_members(self, members: list[LocalUser]) -> LocalGroup:
+    def remove_members(self, members: list[GroupMemberField]) -> LocalGroup:
         """
         Remove multiple group members.
 
-        :param member: List of users or groups to remove from the group.
-        :type member: list[LocalUser]
+        :param members: List of users or groups to remove from the group.
+        :type members: list[GroupMemberField]
         :return: Self.
         :rtype: LocalGroup
         """
-        self.util.logger.info(f'Removing members from group "{self.name}" on {self.util.host.hostname}')
+        self.util.logger.info(f'Removing members from group "{self._name}" on {self.util.host.hostname}')
 
         if not members:
             return self
 
-        cmd = "\n".join([f"groupmems --group '{self.name}' --delete '{x.name}'" for x in members])
+        cmd = "\n".join(
+            [f"groupmems --group '{self._name}' --delete '{self._member_principal_name(x)}'" for x in members]
+        )
         self.util.host.conn.run("set -ex\n" + cmd, log_level=ProcessLogLevel.Error)
 
         return self
@@ -576,22 +718,22 @@ class LocalNetgroupMember(GenericNetgroupMember):
         self,
         *,
         host: str | None = None,
-        user: LocalUser | str | None = None,
+        user: GenericUser | str | None = None,
         group: LocalGroup | str | None = None,
         hostgroup: str | None = None,
-        ng: LocalNetgroup | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> None:
         """
         :param host: Host part of the triple, defaults to None.
         :type host: str | None, optional
         :param user: User part of the triple, defaults to None.
-        :type user: LocalUser | str | None, optional
+        :type user: GenericUser | str | None, optional
         :param group: Not supported for local netgroups.
         :type group: LocalGroup | str | None, optional
         :param hostgroup: Not supported for local netgroups.
         :type hostgroup: str | None, optional
         :param ng: Nested netgroup, defaults to None.
-        :type ng: LocalNetgroup | str | None, optional
+        :type ng: GenericNetgroup | str | None, optional
 
         :raises :class:`ValueError` for unsupported member kinds.
         """
@@ -624,9 +766,14 @@ class LocalNetgroupMember(GenericNetgroupMember):
         return f"({h},{u},)"
 
 
-class LocalNetgroup(object):
+class LocalNetgroup(GenericNetgroup):
     """
-    Local netgroup management via.
+    Local netgroup management via ``/etc/netgroup``.
+
+    :class:`LocalNetgroup` is a :class:`GenericNetgroup` for static typing. Only
+    :class:`LocalNetgroupMember` instances are supported in :meth:`add_members`
+    and :meth:`remove_members` (not arbitrary :class:`GenericNetgroupMember`
+    subclasses from other backends).
     """
 
     def __init__(self, util: LocalUsersUtils, name: str) -> None:
@@ -636,15 +783,24 @@ class LocalNetgroup(object):
         :param name: Netgroup name.
         :type name: str
         """
-        self.util = util
-        self.name = name
+        if util._client is None:
+            raise RuntimeError(
+                "LocalNetgroup requires LocalUsersUtils to be bound to a Client (client= in constructor)."
+            )
+        super().__init__(util._client)
+        self.util: LocalUsersUtils = util
+        self._name: str = name
         self._members: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def __str__(self) -> str:
         """
         Return the netgroup name.
         """
-        return self.name
+        return self._name
 
     def _format_line(self) -> str:
         """
@@ -655,8 +811,8 @@ class LocalNetgroup(object):
         """
         if not self._members:
             # Empty triple (,,) — valid NIS form with empty host, user, and domain fields.
-            return f"{self.name}\t(,,)"
-        return f"{self.name}\t" + " ".join(self._members)
+            return f"{self._name}\t(,,)"
+        return f"{self._name}\t" + " ".join(self._members)
 
     def add(self) -> LocalNetgroup:
         """
@@ -666,26 +822,55 @@ class LocalNetgroup(object):
         :rtype: LocalNetgroup
         :raises: :class:`ValueError` for duplicate names.
         """
-        self.util.logger.info(f'Creating local netgroup "{self.name}" on {self.util.host.hostname}')
-        existing = self.util._netgroups.get(self.name)
+        self.util.logger.info(f'Creating local netgroup "{self._name}" on {self.util.host.hostname}')
+        existing = self.util._netgroups.get(self._name)
         if existing is not None and existing is not self:
             raise ValueError(
-                f'Local netgroup "{self.name}" is already managed by another LocalNetgroup instance; '
+                f'Local netgroup "{self._name}" is already managed by another LocalNetgroup instance; '
                 "reuse the object returned from the first client.local.netgroup() call."
             )
-        self.util._netgroup_names_touched.add(self.name)
-        self.util._netgroups[self.name] = self
+        self.util._netgroup_names_touched.add(self._name)
+        self.util._netgroups[self._name] = self
         self.util._rewrite_netgroup_file()
         return self
+
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Get netgroup data from ``getent netgroup`` (reflecting ``/etc/netgroup``).
+
+        Keys include ``cn`` (netgroup name) and ``nisNetgroupTriple`` (member tokens).
+
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericNetgroup` API compatibility.
+        :type opattrs: bool, optional
+        """
+        _ = opattrs
+        self.util.logger.info(f'Fetching local netgroup "{self._name}" on {self.util.host.hostname}')
+        result = self.util.host.conn.exec(
+            ["getent", "netgroup", self._name], raise_on_error=False, log_level=ProcessLogLevel.Silent
+        )
+        if result.rc != 0:
+            return {}
+
+        line = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+        if not line:
+            return {}
+
+        tokens = line.split()
+        if not tokens or tokens[0] != self._name:
+            return {}
+
+        triples = tokens[1:]
+        out: dict[str, list[str]] = {"cn": [self._name], "nisNetgroupTriple": triples}
+        if attrs is None:
+            return out
+        return {k: v for k, v in out.items() if k in attrs}
 
     def add_member(
         self,
         *,
         host: str | None = None,
-        user: LocalUser | str | None = None,
-        group: LocalGroup | str | None = None,
-        hostgroup: str | None = None,
-        ng: LocalNetgroup | str | None = None,
+        user: GenericUser | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> LocalNetgroup:
         """
         Add a netgroup member.
@@ -693,9 +878,9 @@ class LocalNetgroup(object):
         :return: Self.
         :rtype: LocalNetgroup
         """
-        return self.add_members([LocalNetgroupMember(host=host, user=user, group=group, hostgroup=hostgroup, ng=ng)])
+        return self.add_members([LocalNetgroupMember(host=host, user=user, ng=ng)])
 
-    def add_members(self, members: list[LocalNetgroupMember]) -> LocalNetgroup:
+    def add_members(self, members: list[GenericNetgroupMember]) -> LocalNetgroup:
         """
         Add multiple netgroup members.
 
@@ -704,20 +889,22 @@ class LocalNetgroup(object):
         already in this netgroup or appears more than once in ``members``, later duplicates are
         skipped (nothing is appended for them).
 
-        :param members: Netgroup members.
-        :type members: list[LocalNetgroupMember]
+        :param members: Netgroup members (must be :class:`LocalNetgroupMember`).
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: LocalNetgroup
         """
-        self.util.logger.info(f'Adding members to local netgroup "{self.name}" on {self.util.host.hostname}')
+        self.util.logger.info(f'Adding members to local netgroup "{self._name}" on {self.util.host.hostname}')
 
         if not members:
             return self
 
-        if self.name not in self.util._netgroups:
-            raise RuntimeError(f'Netgroup "{self.name}" was not created; call add() first')
+        if self._name not in self.util._netgroups:
+            raise RuntimeError(f'Netgroup "{self._name}" was not created; call add() first')
 
         for m in members:
+            if not isinstance(m, LocalNetgroupMember):
+                raise TypeError("Local netgroups only accept LocalNetgroupMember entries.")
             line = m.to_member_string()
             if line in self._members:
                 continue
@@ -729,10 +916,8 @@ class LocalNetgroup(object):
         self,
         *,
         host: str | None = None,
-        user: LocalUser | str | None = None,
-        group: LocalGroup | str | None = None,
-        hostgroup: str | None = None,
-        ng: "LocalNetgroup | str | None" = None,
+        user: GenericUser | str | None = None,
+        ng: GenericNetgroup | str | None = None,
     ) -> LocalNetgroup:
         """
         Remove a netgroup member.
@@ -740,28 +925,32 @@ class LocalNetgroup(object):
         :return: Self.
         :rtype: LocalNetgroup
         """
-        return self.remove_members(
-            [LocalNetgroupMember(host=host, user=user, group=group, hostgroup=hostgroup, ng=ng)]
-        )
+        return self.remove_members([LocalNetgroupMember(host=host, user=user, ng=ng)])
 
-    def remove_members(self, members: list[LocalNetgroupMember]) -> LocalNetgroup:
+    def remove_members(self, members: list[GenericNetgroupMember]) -> LocalNetgroup:
         """
         Remove netgroup members.
 
-        :param members: Members to remove.
-        :type members: list[LocalNetgroupMember]
+        :param members: Members to remove (must be :class:`LocalNetgroupMember`).
+        :type members: list[GenericNetgroupMember]
         :return: Self.
         :rtype: LocalNetgroup
         """
-        self.util.logger.info(f'Removing members from local netgroup "{self.name}" on {self.util.host.hostname}')
+        self.util.logger.info(f'Removing members from local netgroup "{self._name}" on {self.util.host.hostname}')
 
         if not members:
             return self
 
-        if self.name not in self.util._netgroups:
-            raise RuntimeError(f'Netgroup "{self.name}" was not  created; call add() first')
+        if self._name not in self.util._netgroups:
+            raise RuntimeError(f'Netgroup "{self._name}" was not created; call add() first')
 
-        remove_strings = {m.to_member_string() for m in members}
+        local_members: list[LocalNetgroupMember] = []
+        for m in members:
+            if not isinstance(m, LocalNetgroupMember):
+                raise TypeError("Local netgroups only accept LocalNetgroupMember entries.")
+            local_members.append(m)
+
+        remove_strings = {m.to_member_string() for m in local_members}
         self._members = [x for x in self._members if x not in remove_strings]
         self.util._rewrite_netgroup_file()
         return self
@@ -770,10 +959,10 @@ class LocalNetgroup(object):
         """
         Remove this netgroup from ``/etc/netgroup``.
         """
-        self.util.logger.info(f'Deleting local netgroup "{self.name}" on {self.util.host.hostname}')
-        self.util._netgroup_names_touched.add(self.name)
-        if self.name in self.util._netgroups:
-            del self.util._netgroups[self.name]
+        self.util.logger.info(f'Deleting local netgroup "{self._name}" on {self.util.host.hostname}')
+        self.util._netgroup_names_touched.add(self._name)
+        if self._name in self.util._netgroups:
+            del self.util._netgroups[self._name]
         self._members.clear()
         self.util._rewrite_netgroup_file()
 
@@ -936,17 +1125,12 @@ class LocalSudoAlias(object):
             self.util._sudoaliases.remove(self)
 
 
-LocalSudoRuleUserPiece = str | LocalUser | LocalGroup | LocalSudoAlias
-LocalSudoRuleUserArg = LocalSudoRuleUserPiece | list[LocalSudoRuleUserPiece]
-LocalSudoRuleHostArg = str | LocalSudoAlias | list[str | LocalSudoAlias]
-LocalSudoRuleCommandArg = str | LocalSudoAlias | list[str | LocalSudoAlias]
-LocalSudoRuleRunAsUserArg = str | LocalUser | LocalSudoAlias | list[str | LocalUser | LocalSudoAlias]
-LocalSudoRuleRunAsGroupArg = str | LocalGroup | LocalSudoAlias | list[str | LocalGroup | LocalSudoAlias]
-
-
-class LocalSudoRule(object):
+class LocalSudoRule(GenericSudoRule):
     """
-    Local sudo rule management.
+    Local sudo rule management (``/etc/sudoers.d/`` drop-ins).
+
+    See :class:`GenericSudoRule` for parameter meanings. ``ProtocolName`` values
+    (including :class:`LocalSudoAlias`) are emitted as bare sudoers names.
     """
 
     default_user: str = "ALL"
@@ -959,37 +1143,45 @@ class LocalSudoRule(object):
         :param name: Sudo rule name.
         :type name: str
         """
-        self.name = name
-        self.util = util
+        if util._client is None:
+            raise RuntimeError(
+                "LocalSudoRule requires LocalUsersUtils to be bound to a Client (client= in constructor)."
+            )
+        super().__init__(util._client)
+        self._name: str = name
+        self.util: LocalUsersUtils = util
         self.__rule: dict[str, Any] = dict()
         self.filename: str | None = None
         self.rule_str: str | None = None
 
-    def __str__(self):
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
         """
         Returns a string representation of the LocalSudoRule.
         """
         if self.rule_str:
             return self.rule_str
-        else:
-            return self.name
+        return self._name
 
     @staticmethod
     def _format_list_item(item: str | Any, add_percent: bool = False) -> str:
         """
         Format a single sudoers list element.
 
-        :param item: String, :class:`LocalUser`, :class:`LocalGroup`, or :class:`LocalSudoAlias`.
+        :param item: String, user/group, or name reference (e.g. :class:`LocalSudoAlias`).
         :type item: str | Any
-        :param add_percent: If true, prepend ``%`` to :class:`LocalGroup` entries.
+        :param add_percent: If true, prepend ``%`` to :class:`GenericGroup` entries.
         :type add_percent: bool, optional
         :return: Formatted fragment.
         :rtype: str
         """
         if isinstance(item, LocalSudoAlias):
             return item.name
-        if isinstance(item, LocalGroup) and add_percent:
-            return f"%{str(item)}"
+        if isinstance(item, GenericGroup) and add_percent:
+            return f"%{item.name}"
         return str(item)
 
     @staticmethod
@@ -999,7 +1191,7 @@ class LocalSudoRule(object):
 
         :param item: A single value or list of values to format.
         :type item: str | Any | list[str | Any]
-        :param add_percent: If true, prepend ``%`` to :class:`LocalGroup` entries (sudo user field).
+        :param add_percent: If true, prepend ``%`` to :class:`GenericGroup` entries (sudo user field).
         :type add_percent: bool, optional
         :return: Formatted string.
         :rtype: str
@@ -1008,15 +1200,41 @@ class LocalSudoRule(object):
             return ", ".join(LocalSudoRule._format_list_item(x, add_percent) for x in item)
         return LocalSudoRule._format_list_item(item, add_percent)
 
+    def get(self, attrs: list[str] | None = None, *, opattrs: bool = False) -> dict[str, list[str]] | None:
+        """
+        Return rule text as attributes (``cn``, ``sudoRule``).
+
+        If ``rule_str`` is unset, reads the drop-in file when ``filename`` is set.
+
+        :param opattrs: Ignored (LDAP-only); present for :class:`GenericSudoRule` API compatibility.
+        :type opattrs: bool, optional
+        """
+        _ = opattrs
+        line = self.rule_str.strip() if self.rule_str else ""
+        if not line and self.filename:
+            result = self.util.host.conn.exec(
+                ["cat", f"/etc/sudoers.d/{self.filename}"],
+                raise_on_error=False,
+                log_level=ProcessLogLevel.Silent,
+            )
+            if result.rc == 0:
+                line = result.stdout.strip()
+        if not line:
+            return {}
+        data: dict[str, list[str]] = {"cn": [self._name], "sudoRule": [line]}
+        if attrs is None:
+            return data
+        return {k: v for k, v in data.items() if k in attrs}
+
     def add(
         self,
         *,
-        user: LocalSudoRuleUserArg | None = default_user,
-        host: LocalSudoRuleHostArg | None = default_host,
-        command: LocalSudoRuleCommandArg | None = default_command,
+        user: SudoRuleUserField = default_user,
+        host: SudoRuleHostField = default_host,
+        command: SudoRuleCommandField = default_command,
         option: str | list[str] | None = None,
-        runasuser: LocalSudoRuleRunAsUserArg | None = None,
-        runasgroup: LocalSudoRuleRunAsGroupArg | None = None,
+        runasuser: SudoRuleRunAsUserField = None,
+        runasgroup: SudoRuleRunAsGroupField = None,
         order: int | None = None,
         nopasswd: bool | None = None,
     ) -> LocalSudoRule:
@@ -1024,17 +1242,17 @@ class LocalSudoRule(object):
         Create new sudo rule.
 
         :param user: sudoUser attribute, defaults to ALL.
-        :type user: LocalSudoRuleUserArg | None
+        :type user: SudoRuleUserField, optional
         :param host: sudoHost attribute, defaults to ALL.
-        :type host: LocalSudoRuleHostArg | None
+        :type host: SudoRuleHostField, optional
         :param command: sudoCommand attribute, defaults to ALL.
-        :type command: LocalSudoRuleCommandArg | None
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None.
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None.
-        :type runasuser: LocalSudoRuleRunAsUserArg | None, optional
+        :type runasuser: SudoRuleRunAsUserField, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None.
-        :type runasgroup: LocalSudoRuleRunAsGroupArg | None, optional
+        :type runasgroup: SudoRuleRunAsGroupField, optional
         :param order: sudoOrder attribute, defaults to None.
         :type order: int | None, optional
         :param nopasswd: If true, no authentication is required (NOPASSWD), defaults to None (no change)
@@ -1044,7 +1262,7 @@ class LocalSudoRule(object):
         """
         orderstr = f"{order:02d}" if order is not None else str(len(self.util._sudorules))
         if self.filename is None:
-            self.filename = f"{orderstr}_{self.name}"
+            self.filename = f"{orderstr}_{self._name}"
 
         # Remember arguments so we can use them in modify if needed
         self.__rule = dict[str, Any](
@@ -1078,35 +1296,37 @@ class LocalSudoRule(object):
     def modify(
         self,
         *,
-        user: LocalSudoRuleUserArg | None = None,
-        host: LocalSudoRuleHostArg | None = None,
-        command: LocalSudoRuleCommandArg | None = None,
+        user: SudoRuleUserField = None,
+        host: SudoRuleHostField = None,
+        command: SudoRuleCommandField = None,
         option: str | list[str] | None = None,
-        runasuser: LocalSudoRuleRunAsUserArg | None = None,
-        runasgroup: LocalSudoRuleRunAsGroupArg | None = None,
+        runasuser: SudoRuleRunAsUserField = None,
+        runasgroup: SudoRuleRunAsGroupField = None,
         order: int | None = None,
         nopasswd: bool | None = None,
     ) -> LocalSudoRule:
         """
-        Modify existing Local sudo rule.
+        Modify existing local sudo rule.
+
+        Parameters set to ``None`` keep the previous values.
 
         :param user: sudoUser attribute, defaults to None.
-        :type user: LocalSudoRuleUserArg | None, optional
+        :type user: SudoRuleUserField, optional
         :param host: sudoHost attribute, defaults to None.
-        :type host: LocalSudoRuleHostArg | None, optional
-        :param command: sudoCommand attribute defaults to None.
-        :type command: LocalSudoRuleCommandArg | None, optional
+        :type host: SudoRuleHostField, optional
+        :param command: sudoCommand attribute, defaults to None.
+        :type command: SudoRuleCommandField, optional
         :param option: sudoOption attribute, defaults to None.
         :type option: str | list[str] | None, optional
         :param runasuser: sudoRunAsUser attribute, defaults to None.
-        :type runasuser: LocalSudoRuleRunAsUserArg | None, optional
+        :type runasuser: SudoRuleRunAsUserField, optional
         :param runasgroup: sudoRunAsGroup attribute, defaults to None.
-        :type runasgroup: LocalSudoRuleRunAsGroupArg | None, optional
+        :type runasgroup: SudoRuleRunAsGroupField, optional
         :param order: sudoOrder attribute, defaults to None.
         :type order: int | None, optional
         :param nopasswd: If true, no authentication is required (NOPASSWD), defaults to None (no change).
         :type nopasswd: bool | None, optional
-        :return:  New sudo rule object.
+        :return: Self.
         :rtype: LocalSudoRule
         """
         self.delete()

--- a/sssd_test_framework/utils/network.py
+++ b/sssd_test_framework/utils/network.py
@@ -16,7 +16,6 @@ __all__ = ["NetworkUtils", "IPUtils"]
 
 
 class NetworkUtils(MultihostUtility[MultihostHost]):
-
     def __init__(self, host: MultihostHost, fs: LinuxFileSystem) -> None:
         """
         :param host: Remote host.

--- a/sssd_test_framework/utils/sbus.py
+++ b/sssd_test_framework/utils/sbus.py
@@ -188,10 +188,10 @@ class ProxyMethod(ProxyObject):
                     )
                 objargs.append(obj)
 
-        method = f'{self.interface}.{self.child.attrib["name"]}'
+        method = f"{self.interface}.{self.child.attrib['name']}"
         res = self._run(method, *tuple(objargs))
         if res.rc != 0:
-            raise RuntimeError(f'Execution of \'{self.child.attrib["name"]}{args}\' failed: ' + res.stderr)
+            raise RuntimeError(f"Execution of '{self.child.attrib['name']}{args}' failed: " + res.stderr)
 
         # Skip output processing if no output is expected
         if self.output is None or len(self.output) == 0:

--- a/sssd_test_framework/utils/tools.py
+++ b/sssd_test_framework/utils/tools.py
@@ -285,7 +285,7 @@ class GroupEntry(object):
         """
 
     def __str__(self) -> str:
-        return f'({self.name}:{self.password}:{self.gid}:{",".join(self.members)})'
+        return f"({self.name}:{self.password}:{self.gid}:{','.join(self.members)})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -348,7 +348,7 @@ class InitgroupsEntry(object):
         """
 
     def __str__(self) -> str:
-        return f'({self.name}:{",".join([str(i) for i in self.groups])})'
+        return f"({self.name}:{','.join([str(i) for i in self.groups])})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -474,7 +474,7 @@ class NetgroupEntry(object):
         """
 
     def __str__(self) -> str:
-        return f'{self.name} {" ".join(map(str, self.members))})'
+        return f"{self.name} {' '.join(map(str, self.members))})"
 
     def __repr__(self) -> str:
         return str(self)


### PR DESCRIPTION
We want all Users, Groups, SudoRules to have the same interface as generic ones.
Fix black formatting anti-pattern when manually split strings are put on the same line
without removing the quotes.  Fix E741 violation in automount.py.

Co-written with Cursor IDE.