### PR TITLE
Fix IPA passkey feature detection

### DIFF
--- a/sssd_test_framework/hosts/ipa.py
+++ b/sssd_test_framework/hosts/ipa.py
@@ -86,7 +86,7 @@ class IPAHost(BaseDomainHost, BaseLinuxHost):
             set -ex
 
             [ -f "/usr/libexec/sssd/passkey_child" ] && \
-                ipa help user | grep user-add-passkey 1> /dev/null && \
+                ipa user-add-passkey --help >/dev/null 2>&1 && \
                 echo "passkey" || :
             """,
             log_level=ProcessLogLevel.Error,


### PR DESCRIPTION
Replace `ipa help user | grep user-add-passkey` with direct command test `ipa user-add-passkey --help` to avoid terminal environment issues when running in SSH sessions without proper TTY allocation.