### PR TITLE
Add BigLDAP topology

### DIFF
--- a/sssd_test_framework/topology.py
+++ b/sssd_test_framework/topology.py
@@ -10,6 +10,7 @@ from pytest_mh import KnownTopologyBase, KnownTopologyGroupBase, Topology, Topol
 from .config import SSSDTopologyMark
 from .topology_controllers import (
     ADTopologyController,
+    BigLDAPTopologyController,
     ClientTopologyController,
     GDMTopologyController,
     IPATopologyController,
@@ -213,6 +214,17 @@ class KnownTopology(KnownTopologyBase):
     )
     """
     .. topology-mark:: KnownTopology.Keycloak
+    """
+
+    BigLDAP = SSSDTopologyMark(
+        name="big-ldap",
+        topology=Topology(TopologyDomain("sssd", client=1, ldap=1)),
+        controller=BigLDAPTopologyController(),
+        domains=dict(test="sssd.ldap[0]"),
+        fixtures=dict(client="sssd.client[0]", ldap="sssd.ldap[0]", provider="sssd.ldap[0]"),
+    )
+    """
+    .. topology-mark:: KnownTopology.BigLDAP
     """
 
 

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -25,6 +25,7 @@ __all__ = [
     "IPATrustADTopologyController",
     "IPATrustSambaTopologyController",
     "KeycloakTopologyController",
+    "BigLDAPTopologyController",
 ]
 
 
@@ -417,3 +418,18 @@ class GDMTopologyController(ProvisionedBackupTopologyController):
         ipa.conn.run("ipa idp-del keycloak")
 
         super().topology_teardown()
+
+
+class BigLDAPTopologyController(ProvisionedBackupTopologyController):
+    """
+    LDAP Topology Controller with large amount of users and large groups.
+    """
+
+    @BackupTopologyController.restore_vanilla_on_error
+    def topology_setup(self, client: ClientHost, ldap: LDAPHost) -> None:
+        ldap.conn.run(
+            "systemctl stop dirsrv@localhost.service && "
+            "dsctl slapd-localhost bak2db largedata && "
+            "systemctl start dirsrv@localhost.service"
+        )
+        super().topology_setup()


### PR DESCRIPTION
This patch expects that ldap container/vm has ldap backup 'largedata'. This backup is restored when BigLDAP topology is used.

Restore process is quite fast (~2s).