### PR TITLE
ci: Add python linters for reverse dependency testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,36 @@ jobs:
 
         # Install system tests requirements
         pip3 install -r ./requirements.txt
+        pip3 install flake8 pycodestyle isort mypy black
 
         # Install yq to parse yaml files
         sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
         sudo chmod a+x /usr/local/bin/yq
+
+    - name: flake8
+      if: always()
+      working-directory: ./sssd/src/tests/system
+      run: source .venv/bin/activate && flake8 .
+
+    - name: pycodestyle
+      if: always()
+      working-directory: ./sssd/src/tests/system
+      run: source .venv/bin/activate && pycodestyle .
+
+    - name: isort
+      if: always()
+      working-directory: ./sssd/src/tests/system
+      run: source .venv/bin/activate && isort --check-only .
+
+    - name: black
+      if: always()
+      working-directory: ./sssd/src/tests/system
+      run: source .venv/bin/activate && black --check --diff .
+
+    - name: mypy
+      if: always()
+      working-directory: ./sssd/src/tests/system
+      run: source .venv/bin/activate && mypy --install-types --non-interactive tests
 
     - name: Install test framework
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             echo 'skipenv=.*-upstream$' >> $GITHUB_OUTPUT
             ;;
         esac
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -60,12 +60,12 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.x
 
     - name: Checkout sssd-test-framework repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         # Fetch the entire history of the repository and tags to determine
         # correct framework version, as it is constructed from git describe
@@ -74,7 +74,7 @@ jobs:
         path: sssd-test-framework
 
     - name: Checkout sssd repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: SSSD/sssd
         path: sssd


### PR DESCRIPTION
In some cases changes in the SSSD test framework code can cause python linters run in SSSD repo to fail such as `mypy`, this PR should catch this if it happens.