### PR TITLE
Adcs smartcard setup v2

### DIFF
--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -2659,7 +2659,7 @@ class ADCertificateAuthority(GenericCertificateAuthority):
             FriendlyName = "Enrollment Agent"
 
             [RequestAttributes]
-            CertificateTemplate = "EnrollmentAgent2"
+            CertificateTemplate = "EnrollmentAgent_IDMTEST"
             "@
             Set-Content -Path "{inf_path}" -Value $infContent
         """)

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -183,21 +183,18 @@ class AD(BaseWindowsRole[ADHost]):
                 }
         """
 
-    #
-    # Disabling CA functionality until sssd-ci-container updated
-    #
-    #        self._ca = ADCertificateAuthority(self.host)
-    #        """
-    #        AD Certificate Authority server management.
-    #
-    #        Provides certificate operations:
-    #        - Request certificates using templates
-    #        - Request smartcard certificates with Enrollment Agent
-    #        - Revoke certificates with configurable reasons
-    #        - Manage certificate holds
-    #        - Export certificates as PFX
-    #        - Retrieve certificate and template details
-    #        """
+        self._ca = ADCertificateAuthority(self.host)
+        """
+        AD Certificate Authority server management.
+
+        Provides certificate operations:
+        - Request certificates using templates
+        - Request smartcard certificates with Enrollment Agent
+        - Revoke certificates with configurable reasons
+        - Manage certificate holds
+        - Export certificates as PFX
+        - Retrieve certificate and template details
+        """
 
     @property
     def password_policy(self) -> ADPasswordPolicy:
@@ -217,47 +214,44 @@ class AD(BaseWindowsRole[ADHost]):
         """
         return self._password_policy
 
-    #
-    # Disabling CA functionality until sssd-ci-container updated
-    #
-    #    @property
-    #    def ca(self) -> ADCertificateAuthority:
-    #        """
-    #        AD Certificate Authority management.
-    #
-    #        Provides certificate operations:
-    #
-    #        - Request certificates using templates
-    #        - Request smartcard certificates with Enrollment Agent
-    #        - Revoke certificates with configurable reasons
-    #        - Manage certificate holds
-    #        - Export certificates as PFX
-    #        - Retrieve certificate and template details
-    #
-    #        .. code-block:: python
-    #            :caption: Example usage
-    #
-    #            @pytest.mark.topology(KnownTopology.AD)
-    #            def test_example(client: Client, ad: AD):
-    #                # Request smartcard certificate
-    #                cert, key, csr = ad.ca.request(
-    #                    template="SmartcardLogon",
-    #                    subject="CN=testuser"
-    #                )
-    #
-    #                # Get certificate details
-    #                cert_details = ad.ca.get(cert)
-    #
-    #                # Place certificate on hold (temporary revocation)
-    #                ad.ca.revoke_hold(cert)
-    #
-    #                # Remove hold (restore certificate)
-    #                ad.ca.revoke_hold_remove(cert)
-    #
-    #                # Permanently revoke certificate
-    #                ad.ca.revoke(cert, reason="key_compromise")
-    #        """
-    #        return self._ca
+    @property
+    def ca(self) -> ADCertificateAuthority:
+        """
+        AD Certificate Authority management.
+
+        Provides certificate operations:
+
+        - Request certificates using templates
+        - Request smartcard certificates with Enrollment Agent
+        - Revoke certificates with configurable reasons
+        - Manage certificate holds
+        - Export certificates as PFX
+        - Retrieve certificate and template details
+
+        .. code-block:: python
+            :caption: Example usage
+
+            @pytest.mark.topology(KnownTopology.AD)
+            def test_example(client: Client, ad: AD):
+                # Request smartcard certificate
+                cert, key, csr = ad.ca.request(
+                    template="SmartcardLogon",
+                    subject="CN=testuser"
+                )
+
+                # Get certificate details
+                cert_details = ad.ca.get(cert)
+
+                # Place certificate on hold (temporary revocation)
+                ad.ca.revoke_hold(cert)
+
+                # Remove hold (restore certificate)
+                ad.ca.revoke_hold_remove(cert)
+
+                # Permanently revoke certificate
+                ad.ca.revoke(cert, reason="key_compromise")
+        """
+        return self._ca
 
     @property
     def naming_context(self) -> str:

--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -2824,7 +2824,7 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         self.export_pfx(cert_path, pfx_path)
 
         self.host.conn.run(
-            f'"Secret123" | & openssl pkcs12 -in {pfx_path} -nocerts -nodes -out {extracted_key_path} -passin stdin'
+            f"openssl pkcs12 -in {pfx_path} -nocerts -nodes -out {extracted_key_path} -passin pass:Secret123"
         )
 
         self.host.conn.run(f"openssl rsa -in {extracted_key_path} -out {key_path}")
@@ -3068,24 +3068,25 @@ class ADCertificateAuthority(GenericCertificateAuthority):
         :rtype: str
         :raises RuntimeError: If CA certificate cannot be retrieved.
         """
+        ca_name = self._get_ca_config().split("\\", 1)[1].strip('"')
         result = self.host.conn.run(
-            textwrap.dedent("""\
-                $ca = Get-ChildItem -Path Cert:\\LocalMachine\\Root | Where-Object {
-                    $_.Subject -like '*CN=ad-RootCA*' -and $_.Issuer -eq $_.Subject
-                } | Select-Object -First 1
-                if ($ca) {
+            textwrap.dedent(f"""\
+                $ca = Get-ChildItem -Path Cert:\\LocalMachine\\Root | Where-Object {{
+                    $_.Subject -like '*CN={ca_name}*' -and $_.Issuer -eq $_.Subject
+                }} | Select-Object -First 1
+                if ($ca) {{
                     [System.Convert]::ToBase64String($ca.Export('Cert'))
-                } else {
-                    $ca = Get-ChildItem -Path Cert:\\LocalMachine\\My | Where-Object {
-                        $_.Subject -like '*CN=ad-RootCA*'
-                    } | Select-Object -First 1
-                    if ($ca) {
+                }} else {{
+                    $ca = Get-ChildItem -Path Cert:\\LocalMachine\\My | Where-Object {{
+                        $_.Subject -like '*CN={ca_name}*'
+                    }} | Select-Object -First 1
+                    if ($ca) {{
                         [System.Convert]::ToBase64String($ca.Export('Cert'))
-                    } else {
+                    }} else {{
                         Write-Error "CA certificate not found"
                         exit 1
-                    }
-                }
+                    }}
+                }}
             """),
             raise_on_error=False,
         )

--- a/sssd_test_framework/topology_controllers.py
+++ b/sssd_test_framework/topology_controllers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import tempfile
+import textwrap
 
 from pytest_mh import BackupTopologyController
 from pytest_mh.conn import ProcessResult
@@ -66,10 +67,14 @@ class ProvisionedBackupTopologyController(BackupTopologyController[SSSDMultihost
         """
         Helper method for joining domains
         """
+        client.fs.backup("/etc/krb5.conf")
+        client.fs.backup("/etc/krb5.keytab")
         self.logger.info(f"Enrolling {client.hostname} into {provider.domain}")
 
         # Remove any existing Kerberos configuration and keytab
-        client.fs.rm("/etc/krb5.conf")
+        # Skip removing krb5.conf when provider is AD
+        if not isinstance(provider, (ADHost)):
+            client.fs.rm("/etc/krb5.conf")
         client.fs.rm("/etc/krb5.keytab")
 
         # First check if joined.  If so, leave.
@@ -99,6 +104,18 @@ class ProvisionedBackupTopologyController(BackupTopologyController[SSSDMultihost
             else:
                 client.conn.exec(["realm", "leave", "--unattended", provider.domain], input=provider.adminpw)
             client.conn.exec(["realm", "join", provider.domain], input=provider.adminpw)
+
+        if isinstance(provider, (ADHost)):
+            ad_krb5_content = textwrap.dedent(f"""\
+                [realms]
+                {provider.realm} = {{
+                    default_domain = {provider.domain}
+                    pkinit_anchors = FILE:/etc/sssd/pki/sssd_auth_ca_db.pem
+                    pkinit_eku_checking = kpServerAuth
+                    pkinit_kdc_hostname = {provider.hostname}
+                }}
+            """)
+            client.fs.write("/etc/krb5.conf.d/ad_pkinit", ad_krb5_content)
 
 
 class ClientTopologyController(ProvisionedBackupTopologyController):


### PR DESCRIPTION
* AD role: change Enrollment Agent name

Changing the default Certificate Template name for the Enrollment Agent template from EnrollmentAgent4 to EnrollmentAgent_IDMTEST.

* topology_controller:  update join_domain for ad

Updates for better AD support including with smart card tests that require a pkinit_anchor for the krb5 config.

Also backing up krb5.conf and krb5.keytab to make setup/teardown a little cleaner.

Skipping krb5.conf removal for AD tests so there is a functional version for use.

* Re-Enable AD CA along with containers update

Re-enabling AD CA role support for smart card testing to align with sssd-ci-containers change to enable this funtionality.
    
Depends-on: https://github.com/SSSD/sssd-ci-containers/pull/174