### PR TITLE
Fix: increase vfido touch delay to avoid IPA auth timeout

### DIFF
--- a/sssd_test_framework/utils/authentication.py
+++ b/sssd_test_framework/utils/authentication.py
@@ -789,7 +789,9 @@ class SUAuthenticationUtils(MultihostUtility[MultihostHost]):
             }}
 
             # Phase 4: Device touch
-            sleep 2
+            # IPA backend lookups can take longer than 2s, especially for
+            # the 3rd+ user in sequential auth tests on fedora-43/rawhide.
+            sleep 5
             spawn {test_venv_bin}/vfido_touch
             set ID_touch $spawn_id
 


### PR DESCRIPTION
The 2-second sleep before vfido_touch was too short for IPA backend lookups on fedora-43/rawhide, causing the 3rd sequential passkey authentication to fail in test_passkey__su_user_same_key_for_other_users.