### PR TITLE
ci: pin tox<4.56 to fix tox-gh Python version filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev libssh-dev
 
         python -m pip install --upgrade pip
-        pip install tox tox-gh
+        pip install 'tox<4.56' tox-gh
     - name: Prepare tox environment and install packages
       run: |
         tox --skip-env '${{ steps.skipenv.outputs.skipenv }}' --colored=yes --notest


### PR DESCRIPTION
tox 4.56 broke tox-gh's [gh] section mapping, causing the py311 env to run even when Python 3.x is active. This results in "could not find python interpreter matching any of the specs py311" failures on the tox (3.x, *) CI jobs.