### PR TITLE
ci: fix tox-gh configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,5 @@ commands =
 
 [gh]
 python =
-    3.x = {py3,lint,docs}{,-upstream}
+    3 = {py3,lint,docs}{,-upstream}
     3.11 = {py311,lint,docs}{,-upstream}


### PR DESCRIPTION
tox-gh does not recognize 3.x as a valid version and falls back to
letting tox choose the environments, therefore all envs are executed
even if 3.11 interpreter is not installed.
