### PR TITLE
roles: add gpo filesyspath method

### DIFF
--- a/sssd_test_framework/roles/ad.py
+++ b/sssd_test_framework/roles/ad.py
@@ -2256,6 +2256,27 @@ class GPO(GenericGPO):
 
         return self
 
+    def filesyspath(self, path: str) -> GPO:
+        """
+        Overwrite the GPO's ``gPCFileSysPath`` attribute.
+
+        Implements :meth:`GenericGPO.filesyspath`.
+
+        Modifies the GPO 'gPCFileSysPath' attribute in LDAP.
+        This should not be used in any circumstance, added to verify a bug.
+
+        :param path: gPCFileSysPath value.
+        :type path: str
+        :return: Group policy object
+        :rtype: GPO
+        """
+        self.host.conn.run(rf"""
+            $ErrorActionPreference = "Stop"
+            Set-ADObject -Identity "{self.dn}" -Replace @{{gPCFileSysPath="{path}"}}
+            """)
+
+        return self
+
 
 class ADPasswordPolicy(GenericPasswordPolicy):
     """

--- a/sssd_test_framework/roles/generic.py
+++ b/sssd_test_framework/roles/generic.py
@@ -1470,6 +1470,21 @@ class GenericGPO(
         """
         pass
 
+    @abstractmethod
+    def filesyspath(self, path: str) -> GenericGPO:
+        """
+        Overwrite the GPO's ``gPCFileSysPath`` attribute.
+
+        Modifies the GPO 'gPCFileSysPath' attribute in LDAP.
+        This should not be used in any circumstance, added to verify a bug.
+
+        :param path: gPCFileSysPath value.
+        :type path: str
+        :return: Self.
+        :rtype: GenericGPO
+        """
+        raise NotImplementedError()
+
 
 class GenericPasswordPolicy(ABC, BaseObject):
     """

--- a/sssd_test_framework/roles/samba.py
+++ b/sssd_test_framework/roles/samba.py
@@ -1381,6 +1381,25 @@ class SambaGPO(SambaObject, GenericGPO):
 
         return self
 
+    def filesyspath(self, path: str) -> SambaGPO:
+        """
+        Overwrite the GPO's ``gPCFileSysPath`` attribute.
+
+        Implements :meth:`GenericGPO.filesyspath`.
+
+        Modifies the GPO 'gPCFileSysPath' attribute in LDAP.
+        This should not be used in any circumstance, added to verify a bug.
+
+        :param path: gPCFileSysPath value.
+        :type path: str
+        :return: Samba group policy object
+        :rtype: SambaGPO
+        """
+        attrs: LDAPRecordAttributes = {"gPCFileSysPath": path}
+        self._modify(attrs)
+
+        return self
+
 
 class SambaPasswordPolicy(GenericPasswordPolicy):
     """


### PR DESCRIPTION
needed to configure an invalid gpcfilesyspath value.