### PR TITLE
utils/sssd: set pwfield=x in local() to fix pam_unix auth with proxy domain

### DIFF
--- a/sssd_test_framework/utils/sssd.py
+++ b/sssd_test_framework/utils/sssd.py
@@ -860,12 +860,25 @@ class SSSDCommonConfiguration(object):
         Create ``local`` SSSD domain for local users.
 
         This is a proxy domain that uses nss_files and PAM system-auth service.
+
+        .. note::
+
+            ``pwfield`` is explicitly set to ``x`` to ensure that ``pam_unix``
+            can authenticate local users. When ``proxy_lib_name=files`` is used
+            with a ``proxy_pam_target`` other than ``sssd-shadowutils``, SSSD
+            returns ``*`` in the password field by default (see SSSD issue
+            `#5129 <https://github.com/SSSD/sssd/issues/5129>`_). This causes
+            ``pam_unix`` to treat the account as locked, breaking SSH and su
+            authentication for local users when ``sss`` appears before ``files``
+            in ``/etc/nsswitch.conf`` (which is the default on many RHEL
+            images).
         """
         self.sssd.dom("local").update(
             enabled="true",
             id_provider="proxy",
             proxy_lib_name="files",
             proxy_pam_target="system-auth",
+            pwfield="x",
         )
         self.sssd.default_domain = "local"
 


### PR DESCRIPTION
## Problem

`SSSDCommonConfiguration.local()` configures SSSD with `id_provider=proxy` and
`proxy_lib_name=files`, which is the standard setup for tests that need local
users (e.g. KCM tests via `client.sssd.common.kcm()`).

When `sss` appears before `files` in `/etc/nsswitch.conf` — which is the default
on many RHEL images — and SSSD is using the proxy+files domain with
`proxy_pam_target=system-auth`, SSH and su authentication for local users fails:

```
pam_unix(sshd:auth): authentication failure; user=tuser
```

This was observed in the upstream SSSD test
[`test_kcm__ccache_holds_multiple_and_all_types_of_principals`](https://github.com/SSSD/sssd/blob/master/src/tests/system/tests/test_kcm.py)
running on RHEL 9.6, where the test consistently fails with
`SSHAuthenticationError` when the client image ships with `passwd: sss files systemd`.

## Root Cause

When `proxy_lib_name=files` is combined with a `proxy_pam_target` other than
`sssd-shadowutils`, SSSD returns `*` in the password field for NSS lookups
instead of `x`. This is a known SSSD behavior documented in
[SSSD issue #5129](https://github.com/SSSD/sssd/issues/5129).

The sequence of events:
1. `getent passwd tuser` (via NSS with `passwd: sss files`) → SSSD proxy returns `tuser:*:1001:...`
2. `pam_unix` sees `*` in the password field → treats account as locked
3. Authentication fails, even though the user exists in `/etc/passwd` and `/etc/shadow`

The fix in SSSD 2.3.0 ([`ae5a2cd`](https://github.com/SSSD/sssd/commit/ae5a2cd)) set
`pwfield=x` automatically for proxy+files, but SSSD 2.3.1 scoped that back to only
apply when `proxy_pam_target=sssd-shadowutils`. Since `local()` uses
`proxy_pam_target=system-auth`, the `*` behavior persists in current SSSD versions.

## Fix

Explicitly set `pwfield=x` in the domain configuration. This ensures `pam_unix`
receives `x` in the password field and correctly falls back to `/etc/shadow` for
authentication, regardless of the `nsswitch.conf` ordering.

```ini
[domain/local]
id_provider = proxy
proxy_lib_name = files
proxy_pam_target = system-auth
pwfield = x
```

## Testing

Verified on RHEL 9.6 (`sssd-2.9.4`) with `passwd: sss files systemd` in
`/etc/nsswitch.conf`:
- **Before fix**: `test_kcm__ccache_holds_multiple_and_all_types_of_principals` fails with `SSHAuthenticationError`
- **After fix** (`pwfield=x`): authentication succeeds, test passes